### PR TITLE
Add McNemar's test educational demo notebook

### DIFF
--- a/McNemarTestDemo.ipynb
+++ b/McNemarTestDemo.ipynb
@@ -1,0 +1,400 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5485d280",
+   "metadata": {},
+   "source": [
+    "# Demo: McNemar's Test for Two Models\n",
+    "\n",
+    "This notebook simulates **correct/incorrect** outcomes for two hypothetical models on the same test set and demonstrates **McNemar's test** step by step.\n",
+    "\n",
+    "McNemar's test is the standard, purpose-built test for **paired binary outcomes** on the same test items. Instead of comparing overall accuracy with an unpaired test, it focuses only on the items where the two models *disagree*.\n",
+    "\n",
+    "You can control:\n",
+    "1. test set size `n`\n",
+    "2. baseline accuracy of model B\n",
+    "3. how much more (or less) accurate model A is than model B\n",
+    "4. how strongly the two models' correctness is correlated (shared difficulty of items)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ff014f79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "\n",
+    "# --- User settings ---\n",
+    "n = 100\n",
+    "acc_b = 0.70          # baseline accuracy of model B\n",
+    "acc_advantage_a = 0.08  # how much more accurate model A is than B (can be negative)\n",
+    "correlation = 0.6     # 0 = independent models, 1 = highly correlated correctness\n",
+    "seed = 42\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e6fc36f",
+   "metadata": {},
+   "source": [
+    "## 1) Simulate paired binary outcomes\n",
+    "\n",
+    "For each test item we draw a shared **difficulty** factor, then decide independently whether each model gets the item right. The `correlation` setting blends each model's outcome toward a shared coin flip, so that easy items tend to be solved by both models and hard items missed by both — just like real paired evaluations.\n",
+    "\n",
+    "Each outcome is `1` (correct) or `0` (incorrect).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7d377238",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 100 paired outcomes.\n",
+      "Target accuracy A: 0.780   Target accuracy B: 0.700\n",
+      "Observed accuracy A: 0.820\n",
+      "Observed accuracy B: 0.680\n",
+      "First 15 pairs (A, B): [(1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 0), (1, 1), (1, 1), (1, 1), (1, 0)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "rng = random.Random(seed)\n",
+    "\n",
+    "acc_a = max(0.0, min(1.0, acc_b + acc_advantage_a))\n",
+    "\n",
+    "def draw_outcome(p, shared, rho):\n",
+    "    \"\"\"Blend an independent draw with a shared draw to induce correlation.\"\"\"\n",
+    "    if rng.random() < rho:\n",
+    "        # Use the shared 'difficulty' draw: item solved iff shared < p\n",
+    "        return 1 if shared < p else 0\n",
+    "    return 1 if rng.random() < p else 0\n",
+    "\n",
+    "outcomes_a = []\n",
+    "outcomes_b = []\n",
+    "for _ in range(n):\n",
+    "    shared = rng.random()  # shared difficulty: small = easy item\n",
+    "    a = draw_outcome(acc_a, shared, correlation)\n",
+    "    b = draw_outcome(acc_b, shared, correlation)\n",
+    "    outcomes_a.append(a)\n",
+    "    outcomes_b.append(b)\n",
+    "\n",
+    "pairs = list(zip(outcomes_a, outcomes_b))\n",
+    "\n",
+    "print(f'Generated {n} paired outcomes.')\n",
+    "print(f'Target accuracy A: {acc_a:.3f}   Target accuracy B: {acc_b:.3f}')\n",
+    "print(f'Observed accuracy A: {sum(outcomes_a)/n:.3f}')\n",
+    "print(f'Observed accuracy B: {sum(outcomes_b)/n:.3f}')\n",
+    "print('First 15 pairs (A, B):', pairs[:15])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8359f74e",
+   "metadata": {},
+   "source": [
+    "## 2) Build the 2×2 contingency table\n",
+    "\n",
+    "McNemar's test summarizes the paired outcomes in a 2×2 table of counts:\n",
+    "\n",
+    "|              | **B correct** | **B wrong** |\n",
+    "|--------------|:-------------:|:-----------:|\n",
+    "| **A correct**|      `a`      |     `b`     |\n",
+    "| **A wrong**  |      `c`      |     `d`     |\n",
+    "\n",
+    "- `a` = both correct (concordant)\n",
+    "- `d` = both wrong (concordant)\n",
+    "- `b` = **A correct, B wrong** (discordant)\n",
+    "- `c` = **A wrong, B correct** (discordant)\n",
+    "\n",
+    "Only the **discordant** cells `b` and `c` carry information about which model is better. The concordant cells `a` and `d` are ignored by the test.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "69e3f859",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contingency table (counts):\n",
+      "               B correct     B wrong\n",
+      "   A correct          60          22\n",
+      "     A wrong           8          10\n",
+      "\n",
+      "Concordant (ignored): a = 60, d = 10\n",
+      "Discordant (used)   : b = 22 (A>B), c = 8 (B>A)\n",
+      "Total discordant pairs: b + c = 30\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = sum(1 for x, y in pairs if x == 1 and y == 1)  # both correct\n",
+    "b = sum(1 for x, y in pairs if x == 1 and y == 0)  # A correct, B wrong\n",
+    "c = sum(1 for x, y in pairs if x == 0 and y == 1)  # A wrong,  B correct\n",
+    "d = sum(1 for x, y in pairs if x == 0 and y == 0)  # both wrong\n",
+    "\n",
+    "print('Contingency table (counts):')\n",
+    "print(f\"{'':>12}{'B correct':>12}{'B wrong':>12}\")\n",
+    "print(f\"{'A correct':>12}{a:>12}{b:>12}\")\n",
+    "print(f\"{'A wrong':>12}{c:>12}{d:>12}\")\n",
+    "print()\n",
+    "print(f'Concordant (ignored): a = {a}, d = {d}')\n",
+    "print(f'Discordant (used)   : b = {b} (A>B), c = {c} (B>A)')\n",
+    "print(f'Total discordant pairs: b + c = {b + c}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "642cbfd9",
+   "metadata": {},
+   "source": [
+    "## 3) Visualize the contingency table and discordant pairs\n",
+    "\n",
+    "These plots build intuition before computing the test statistic:\n",
+    "- **Left:** the 2×2 table as a heatmap, highlighting concordant vs discordant cells\n",
+    "- **Right:** the two discordant counts `b` and `c` side by side — McNemar's test asks whether these two are meaningfully imbalanced\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "110385f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABFAAAAGGCAYAAABc2HWpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAfttJREFUeJzt3QWYVOX3wPGzCSxdS3dKd5dISxh0K6WIIPhHQVDip6IYGNgCBoJBiJIiDdLd3d1Lbs7/OS/ecWZ2dmcXdtn6fp5n2Jl779z7zp3LzL1nznteL5vNZhMAAAAAAABEyTvqWQAAAAAAACCAAgAAAAAAEANkoAAAAAAAAHhAAAUAAAAAAMADAigAAAAAAAAeEEABAAAAAADwgAAKAAAAAACABwRQAAAAAAAAPCCAAgAAAAAA4AEBFOABZcqUSQYMGMB+jEdeXl4ybNgw3g8AAESkRo0a0qhRoyS3L1KnTi0vvfSSJHeXLl0y5y4fffRRQjcFQBwjgAK3IiIiZOHChdK+fXspWLCgpEuXTsqUKSNjxoyRmzdvJpp1Piwp5Qs/PrDvAACIWrNmzczFtnXT8yM9T2rdurVMmjRJ7t69y+6LhVOnTpn9OHHiRPYbgDhHAAVubdiwQZo3by5p06aV+fPny7lz5+Tdd9+Vzz//XOrXry8hISGJYp2JwbVr1/iSBgAA903PjWw2m7ldvHhR/vrrL2nYsKEMHz5cypcvL4cOHXJaft26dfL333+zxxOpbNmymfeSH9+A5IcACtzy9/eXH3/8UaZMmSKlSpUyv4Y8/vjjMn78eNmyZYvMmjUrUawTAAAgOUmTJo0UL17cXHzrj0/aHaRNmzYSHh6e0E0DgBSPAArcqlSpknTt2jXS9KJFi5q/R48etU/74YcfTKrkJ5984rTsV199ZaZ/8803sV5ndDSdtVq1aiYAkz17dnn66adl37599vmayTJ69GgpVqyYCdrkyJFDunXrJidPnnRbV2PVqlVStWpV09WkSJEi8t1339mX0SwZXS44OFg+/vhje3qtpttGVwMlJuu2aPelF154QQIDA81ratmypUk/1e5Net/Vt99+K5UrVzYnWBkyZDBZPdu2bbvv7Xvapxrs0r7W7uivYvq+uhOTfVeyZEn7dF9fX8mbN6/07t1bLly44Had+otchQoVzOspUaKEaXdMxWS/AQCQmGhXHg2k7NmzR/74449oa6AsW7bMZK1o9kPGjBmlZs2aMn36dJMJ4Wju3LlmOT1/0Vvjxo1lzZo1Tst88cUXUq5cOfN9mzlzZtOdaPv27U7L6Hf4E088Ibt27TJt0Sya5557zsw7f/68OeezttG9e3cJCgpy+xr1+986F9DztsKFC8vQoUPl1q1b9mU0A0fn63f5zJkz5ZFHHpFUqVKZNi5atMi+3OrVqyVfvnzm/osvvmhfb3S16hzXrT/06fmjvu6KFSvKvHnz7qu97mqgOG5H35fSpUuLn5+feT+UniuVLVvWnIvlzp3b7NutW7dG2W4ACcQGxMKwYcP0W9g2c+ZMp+l9+vSx+fn52f755x/zeNOmTbZUqVLZevTocd/rdOe5554z633vvfdsJ0+etF26dMk2a9Ys2/PPP29fpnXr1rb06dPbpk2bZrt27Zpt48aNtrJly9py5cplO3v2rH053aYu27lzZ9vBgwfNul544QUzfcuWLU7b1W0OGjTIbZsyZsxonucopuuOiIiwNW7c2JY1a1bbn3/+aQsKCrKtXr3a1qpVK1uxYsVsjz/+uNN6BwwYYEuTJo3ts88+s128eNF26tQpW69evWxp06a17dq1675em6d9+umnn5rnbd682el52k6dPnHixGjfs+j2naNbt27ZVq1aZStTpoytbt26tvDwcKfX06JFC1vbtm1thw4dsl24cME2evRoM/3zzz/3+H7EdL8BAPCwNW3a1HwfRWXdunXm+87xu7R69eq2xx57zP5YvxtTp05tltFzHf1O3bBhgzkPOHz4sH25CRMm2Ly8vGxDhgwxz7l+/bptyZIl5vvVMnToUJuPj4/tww8/NOcE+/btM+cqAQEBtq1bt9qXK1GihK1OnTq2Zs2amXOLc+fO2X799VfbnTt3bKVLl7YVKlTItnLlSrON33//3dapUyeP5wR6HjR//nxzzuZ4DqnnMroP2rVrZxs4cKA5Xzlz5ow519Hvd922Refpsnr+EhPWutu0aWPr37+/OUfQdei5rbe3t23BggWxbq+ea+g6dX+7bueJJ54w51jHjx83+1PPnb/88ktzHv3zzz+bdep+1/NCff8AJC4EUBBj27ZtM1/OjzzyiC00NNRp3t27d22VKlWy5c2b17Z//35bwYIFTdDi9u3b971OV+vXrzdfPGPHjo1ymaVLl5pl9EvfkX7565eg45e2Lpc7d27zRW/R9mbIkMEpIHO/AZSYrHvx4sVm2UmTJjk9f/ny5Wa6YwBFg1I6bdy4cU7LhoWF2UqWLGl7+umnY739mOxTPfFJly6drXfv3k7Tu3TpYt67K1eu2OIigGJZuHChaZNrQCh79uyRjqeWLVvasmTJYo6/qN6P2Ow3AAASWwBFL+it4EFUAZSpU6eaZRyDJa40yKDf29FdlJ84ccIET/r27es0XS/qM2fObNrqGEDRZV23+dVXX5m2LFu2zGm6BglcA0FR0R9n9LzN+t63gg/VqlVzWk6DEDr9gw8+eOAASoUKFZym649cpUqVspUrVy7W7Y0ugKLnx646duxozoUBJH504UGMnD592vS/1VRDTTvU9EVHmkY5Y8YM0x1Fu3VcuXLFPNbuEve7TldWGmXnzp2jXGbJkiXm71NPPeU0Xbt7aFqkNd/y2GOPmTRNi7ZXu7ocOXJEHlRM1q3ptqpVq1ZOz9WiutrNxJGV4tmuXTun6T4+PtKgQQNZsWJFrLcfk32q7dA03GnTpsn169ftqan6/up+1tTe+6W1bzRFVbtZ6etw7OLjWjBP04Ndjyd9rh5r0XXFie1+AwAgMbG64Oh3ZFT0HMfb29t0g9URD2/fvh1pmaVLl5oRfaL7ztfvRK214noelT59emnSpIksX77cjKpo0e7G2oXFkZ5r6fL6Hev6nR1V91xdd9asWc1rsLrc6HZcz8e0dp6j/Pnzm23FxXmb67mYtkO7Lu3YscOc99xPe93RdbrSc+e9e/ea7lqbN2+m3g2QiBFAgUdaj0IvXvXLQy+49UPenUKFCpk+tfrlrF+8WgDtQdfp+hyVJ0+eKJe5fPmy+ZszZ85I83Sa4xegypUrl9uAgY6s86Bism5tr375an9lV1oTxbWmiBUM0mCTBgD0uXr78ssv7a89NtuPyT5VWqNFT8a+//5781hrj2htk169esn90pOMunXrSlhYmBlJQINvepKo/ZdVaGio0/IaZHFlTXN9Xx9kvwEAkJhoXTSldTGiorVAtDaIfpe2aNHC1EDR79ipU6fG6XmUfvffuHHDPs3dunQd7r6z9bxGv3sdrVy50tQk01ovOrLQnTt3zLmAVbPN9VwgPs/bojvPsPZLbNvrjrt99vLLL5v6fXPmzJEqVaqY4Ezbtm3ND00AEhcCKIiWfmFooOPEiRMm0KFfxlHRLw8dSad69ermQnvBggUPvE5HWtzUylyJSpYsWezFy1zpNNdARXS/5jyomKxbvyD1Fwt3AQDXQqpW2/X1a9BBfyHS5+pNv7wdfxGK6fZjsk+tX5j0fdKicrpdLRCsAbNHH31U7pdmsGhQ5uuvvza/nFnZJVEVE47qPbX2Y1Riu98AAEhMNONBuWZ0uNIMDx21RzMzf//9d5MhqkX0rSBKXJxHacaxZnxYNIvYlX4nuysGr9Ncv3O1bfr9rz9oaPFWXX905wLxed4Wk/OM2LbXHXf7TKeNGjXKrEdvEyZMMMV569WrZw+gAUgcCKAgShrN1xTFw4cPm24Q2q0kKpre2L9/f+nQoYOp5K5f8vqlrUGS+12nK2tEGu1KEhXttqJmz57tNP3gwYOyc+dO+/zY0sry+qtLXLMCEK5V3nX0HNdq9dbr/+WXX+Js+zHZpxZ9f3VknldeecV8uT/77LMxOpHxtO+skw/HUZ3c0SwVzW5ypL/U6AmiVsqPSnzsNwAAHoZjx46Z0VmiGpnPHR31Rru66I9amnmpWRNKf7zS79zovvP1/E0zNV3PozSzRQM5Ot81i8SVZiPrOYxrF1n9znZHR7JxPJ/QHzpicl4S3XmHiu15m9Xl16I/svz5558mu8fxB7i4bq8rzW555pln5P333zcj+5CFAiQuBFDgln5gawqoXjDrF0p0mQb6JalphgUKFDBDs+kXr9Y00S+Y9u3b29MZY7NOd3SY3X79+slbb70lH3zwgfkFxfqVRS/urS9tPWl444035NdffzVt0y8erX+hv7y8+uqr9/WO64nLP//84/bXiQehAR09odGgxPz5801arG5HvzT1lw1HmtmjQ/INHz7c/DKhwzJrBof+QvHOO+/IkCFDYr39mOxTiw5trOm7H374oTl56tmz5wPtO02B1RM7bffFixfNLyyDBw82acfuaEprjx49TNcfzdh58803zXE0duzYSEGY+N5vAADEF/2xQH/40cCJfk/r+YsGH/T8KiqfffaZ+Q7dtGmTOZfQH6wmTpxoMi+t8y3tQqPfe3qOpl1G9PtUl9V6bFadMB0CeNCgQeZ87pNPPjHnBAcOHDDztbvK22+/7bH9OmSxDjOs3Xz1RzXdhgYiNKDi+n2t9UCuXr0qr7/+uqmzpvXPOnXqFKOu3VHRH1a0u5PWfLFqt8WEvnY9X9BzIb09//zzpi7JuHHj4rW9Ss9vPv30U9m/f78J/Bw/ftxkduuQxnr+AyARSegqtkicdOg0PTyiujlWUH/qqadM9fjdu3c7rWPFihU2X19f24svvhjrdUZFK6JrFXcd8UcryQcGBppRVPbu3WtfRkdkef31121FihQxQ8Jly5bNVJw/duyY07p0m6+++mqkbdSvX99Ut3ekw8zpNN2mPs+xCn1Uo/DEdN03btwwI+PoUMa6H3XkHa2CX7RoUbNvXWml/dq1a5uhmnV5rQ4/YsSISEM0x3T7MdmnFt2vuu7mzZvbYiq6fTdnzhzTfp2nIzeNHz/eDDuty/3222+RXo8OFajV6/39/c0wz1rp35W79yOm+w0AgIdNvxcdz4d0WN78+fPbWrVqZfv222+dRtSLahQePZf45JNPzCg1+j2nI9TpEMM6LK4rHVK4bt26ZoS9TJkymSGKV69e7XReoCPYlClTxnzf6veqnpvoUMWOdBQeHfrXHf1u1ZFldPQ/vel52LVr19yOzKff5cWLF7ePyvjDDz/Ypk+fbvaFNWyyNYLNN998E2lbefLkMSMDuo7oZ7Vfn+fuvMDiuO7JkyfbChcubJ5Xvnx5c57iKibtjW4UHnev4ciRI7bBgweb0QF1vTqSoo665DhsNIDEwUv/SeggDoDIAgICTAqn/qqUWGhmzNChQ039Es1IAQAASMo0i0Szfr/55hszihEARIcuPEAipN15NFU2NjViHgatI6IV6d0NwQcAAAAAyZlvQjcASOl0RBul9WF0KD4t9qb9brUw6pNPPimJgVbN1+ERtW+1ZqG4qyAPAAAAAMkZGShAAtOuMDqKkRZ50wJvGjxp1aqVLF68OFEEKjRoooXr+vTpI88995y89NJLCd0kAAAAAHjoqIECAAAAAADgARkoAAAAAAAAHhBAAQAAAAAA8IAisnFcaPPMmTOSPn168fLyistVA0C0dET6GzduSO7cucXbm9g4HgzfZwAAIKWwxeI8mgBKHNLgSb58+eJylQAQKydPnpS8efOy1/BA+D4DAAApzckYnEcTQIlDmnmi/Ev1EC8f/7hcNVKIWVNeS+gmIIm6ffOGtGtQzv45BDwI6zjSEwkdXh2w/O9//5OpU6dKgQIFJDw8XPbv3y9jxoyRXr16xWoZAAASi6CgIJMIEZPzaAIoccjqtqPBEwIouB9p03Ghgrj5HALi4jjS4AkBFDjSX+YOHjwo6dKlM4+///57efbZZ6Vp06ZSqlSpGC8DAEBSPI+mozwAAABiZNCgQfbAiOrYsaOpmbNt27ZYLQMAQFJEAAUAAAD3ZeXKlebvI4888kDLAACQFBBAAQAAQKxdvHhR+vbtK23btpWKFSve9zIAACQV1EABAABArFy9etXUNNEhH6dMmXLfywBIXLTwc2hoaEI3A4hTfn5+4uPjEyfrIoACAACAGLt27Zo0adJEUqdOLQsXLnSqdxKbZQAkHjabTc6dO2f+7wLJUaZMmSRnzpwPPOACARQAAADEyPXr101gRH/N08CIuyEfY7IMgMTFCp4EBgZKQEAAo/ohWQUHb9++LRcuXDCPc+XK9UDrI4ACAACAGJ2ENmvWzAxR/Mknn8jSpUvt88qUKSNFixaN0TIAEl+3HSt4kjVr1oRuDhDn0qRJY/5qEEWP8wfpzkMABQAAAB5pcCRHjhzmNnPmTKd5zzzzjD2A4mkZAImLVfNEM0+A5Crg3+Nbj3cCKAAAAIhX3t7e8vvvvz/wMgASpwetDQGkhOObYYwBAAAAAEgiXa527dolwcHBKWrbiQUBFAAAAAAA4klISIgJPMTFENE6RHzZsmVNramH7Wo8bjsiIsLsoxs3bkSad/LkSTl+/Ljb5+m8EydOyMNCDRQAAJBgOsztwN4HEqlfWv6S0E0AkgW9wNfAw9GjR6VgwYIJ3ZxEKSgoyOyj2bNnyxNPPOE0b/DgwXLz5k0zspvl0KFD0q5dOzl8+LDpnpM/f3757bffpGTJkvHaTjJQAAAAAABJ1uXLl01wQruYONKsBZ3uSDMcNNPh7t27piuK3g8LCzO3I0eOyJ07d6LczqlTp+TMmTPRtkXn67DQjpkVVsbGgQMHzPZcsyk8rVfbpG3TNnpy69Ytsw1H+jzHrjeOr1v32bFjx6LslhPTbZ+K4jU4bkuHE96/f7/bLJPY0ILlbdu2lXz58pn3Xm/FihWTp556KtIxENcIoAAAAAAAkpyzZ89KkyZNpFChQtKwYUMzDPPEiRPt87dv324yEjZt2mSf1qFDB+nfv7/4+/ubwIZmPbzyyiuSLVs2qVOnjhnm9ocffnDazj///GPWU6lSJalatarZ3vLly52WWbNmjZQqVUqKFy9ultN1aeaJBjQGDRpklnnxxRelY8eOMm7cuBiv96effjIjm+n6tI3Wc6OyceNG85ocAx6XLl1y6npjve4RI0ZIzpw5pX79+pIpUyaZMmVKrLf9j4fXYG1r2LBhkidPHnnyySdNGx/EunXrzHs7duxY8fPzE19fX3N/7969smrVKolPBFAAAAAAAEmKZiG0adPGDI9+8eJFk2miF+6vvfaaLF261CzTunVrefbZZ6VLly4mkPHJJ5+YC/4ff/zRjBrmGPzQrBDNoJgwYYL06dPHZGUonfb444+b9V64cEFOnz4tI0eOlKefftoEJqw6HM2bNzfLXb9+3Tzn3XffNdkW6dOnl/nz55vlFi1aZLIxvvzyyxivt1evXvLBBx+Y5bWNq1evjrN9uG/fPrNOvX344YcyYMAA05Umpts+E4PXYNmxY4fJUtmzZ48JdkVFg066jxxvVpssmzdvNgGwChUq2KeVKVPG7GudF58IoAAAAAAAItGuFprl4XjTQqJKMxxc5+nNohfQrvOs7jEazHCdp90wYkMDIZpZogESDZ5o9oFeVGu2hONw6hoY8PHxkfbt28urr74qX3zxhRQoUMBpXW+88YZkzJjR3O/du7cJynz//ffmsWZlaOZEtWrVzDY0AFCzZk0TgFm5cqV9mcyZM8s777xjtqVq164tjRs3jrL9MVmvtkEzOjSgo7SNo0ePjrMjddSoURIQEGDud+7c2XSxsbJUYrLtKTF4DY77OG3atB7bpAEbzdJxvK1fv95pGT1WNNvIlU5zDdzENYrIAgAAAAAi0V/zV6xY4TRNu2NorQnNCvj666/dXpSrOXPmmIwDR9p9o1y5crJ7925ZsGCB07wiRYpI165dY/wu6AW7Bit69uwZaZ52o7GkSZNGPvvsM5P1oBkpnTp1irS8dr1xVLp0aVOk1NqOvg6tueFIu7ZYASHNNNH9YgVPYtp+T+vVAqnu2hZXcufObb9vBTes+iQx2fbeGLwGiwZjYuLjjz+OVERW169FZC3aZUdHNnJXb0W79MQnAigAAAAAgEgqV64sJUqUcJqWOnVq8zdDhgzSt2/fKPeadq9xHbZX62xYF+JaANSRZo/EhrW8BnlSpUoV7bIaQNEMEe2Cot1MNGvCkevFvmZiZMmSxb4dDfq4ZlS47hPH7JuYtt/TejU75Pz585HaFh0dkcZVTIrP3s+2/WPwGiyxCS55oseOZkJpIWDreNRjTTNTXI+ruEYXHgAAAABAJFpTIleuXE43DURYWQCu8/Rm0aKjrvM0G8TKdnCd565LRnS0i4yOuKLD3rpyzE6YPHmyGf5WC4+WL19eevToYeqnOFq2bJlTkECXrVixonmsXYI2bNhgr4niOLqOFZjQtugyWovFkRVAcrzIt8RkvdoG7b7iGLiw6rtEJXv27Oav44g4W7ZskdiKybbrxOA1xActeqvvodaUsSxevNi87w0aNJD4RAAFAAAAAJCkaJefl156SZ577jlTHFYv9mfOnGkKmP7666/2big6Ao52C9FuPTq6ztatW01dFEdjxowxNT90BBetuaEBHg20KO1WpMGEZs2amfXqdrT2h9b90GwWpUVqdSSapk2byh9//GEyMgYOHCi//PKLma8j3Wj2zdSpU00xVS3IGpP1duvWzWT66MhBuk5tv6caKPo6dUhffd0aCNI2DB48ONb7Nybb7hqD1xAftIaN1qp54YUXTL2bP//8U55//nnp3r27ee3xiS48AAAAAIAkRwMhVapUkWnTppkASOHChc1FtHYfUjrsrhaP1dFkVN68eeWbb76Rt956ywRKLPp8vfDXAqpaQFYzUqysEe2msmTJEhOk0QK02t1HR3zRzBarGK12IdLnvPfee6aQrD5XAzkaWLGydX7++Wczwo9e8GuhVR2JJ6br1eGGX375ZRMcmDFjhhmG2WqfK93WvHnzTNFWDaJoFywNfvTr18/+HP2r3agc64Vo1x+dZtVCicm2/WOwb9xtK6ouPrqcBm1c5c+fP1L3Ie2WpQVnx48fb7JRtNitDkcd37xsrvlLuG9aSEmrE6cq20e8fGLXhw9QC38ey47Afbl1M0ger1LIDJ3n7osHuJ/vs4dxPHWY2yFe1w/g/v3S8t6v50jetI6EjmKjRT6juihPrnSIXC3+qvVLNEsEKfM4D4rFeQ9deAAAAAAAADwggAIAAAAASHFi2r0EsFADBQAAAACQ4mi9E+3GA8QUGSgAAAAAAAAeEEABAAAAAADwgAAKAAAAAKRwDM6K5MwWR4MPE0ABAAAAgBTKKqB6+/bthG4KEG+s4/tBCwZTRBYAAAAAUigfHx/JlCmTXLhwwTwOCAgQLy+vhG4WEGeZJxo80eNbj3M93h8EARQAAAAASMFy5sxp/lpBFCC5yZQpk/04fxAEUAAASCKCg4Plu+++k0WLFsm1a9ekXLlyMmTIEMmfP7/TckeOHJG3335b9u7dK3nz5pWXXnpJatasmWDtBgAkbppxkitXLgkMDJTQ0NCEbg4Qp7TbzoNmnlgIoAAAkES0b99ecufOLV27dpWMGTPKZ599JpUqVZLNmzdLgQIFzDLnz5+XWrVqSf369WX06NHy119/SYMGDWTVqlVSrVq1hH4JAIBETC8y4+pCE0iOCKAAAJBETJ8+3fRNt2iQRDNMpk6dKiNGjDDTPv74Y/H395dp06aZk+DGjRvL9u3bZcyYMTJv3rwEbD0AAEDSxig8AAAkEY7BE+Xr62uCJY7p1kuWLJGmTZs6/YLYqlUrWbZsmURERDzU9gIAACQnBFAAAEiitB7K6dOnpU2bNvZpJ06cMN18HOnjO3fuyKVLl6KsrRIUFOR0AwAAgDMCKAAAJEFr1qyR/v37y5tvvikVK1a0T9dslFSpUjktmyZNGvs8d8aNG2dqqli3fPnyxXPrAQAAkh4CKAAAJDHr16+XFi1ayKBBg2T48OFO87JmzSqXL192mqaZJzrCQubMmd2uT9dx/fp1++3kyZPx2n4AAICkiCKyAAAkIRs2bDA1Tp577jmTOeJKR+XZuHFjpIBLyZIlI9VQsWjGimvWCgAAAJyRgQIAQBKxadMmadKkiQmevPvuu26X6d27t+neo8MXq/3795sReXQ6AAAA7h8ZKAAAJBF9+/aVmzdvyt9//y1VqlSxT9fuPGPHjjX3H3vsMRk/frwpLKvFY0+dOiXdu3c33X0AAABw/wigAACQRPz4449mNB1XWvfE0csvv2yCLceOHZNcuXJJtmzZHmIrAQAAkicCKAAAJBGlS5eO8bLp06eXsmXLxmt7AAAAUhJqoAAAAAAAAHhAAAUAAAAAAMADAigAAAAAAAAeEEABAAAAAADwgAAKAAAAAACABwRQAAAAAAAAPCCAAgAAAAAA4AEBFAAAAAAAAA8IoAAAAAAAAHhAAAUAAAAAAMADAijJUERwkETcvWLu20JvScTNs/Gynfhcd2Jns9kk/MZJsdnCJaW7fOGc7Ni87r6ee+70STl2aJ8kBufPnJIjB/YmdDMAAAAAJFIEUJIZmy1CQo/MFVvITfM4POi4hBxfHEfBkjNO0+Jq3UmBvnZb6G37Yy8vLwm/uEPCL+6UlG7D6qUydkjvWD8vPDxchj/XSc6eOhFp3qF9u2TLupVx0r6ga1dl0z/L7bedW9bLxfPOx7IKCwuVwT3ayLUrl+JkuwAAAACSFwIoyUz45b0iPn7ikyF/nK434sYpCTm2UFKqkKMLJOLmaadpvjmqSNi5jWILD0mwdiVli37/Wfz8/KVmgyZO08NCQ+X/nn1ahvR88r4zWxwd2LPdrO/7z96Tad98LF+9N1q6NasuI17oKsHBd+3L5clfSKrXe0x+/PLDB94mAAAAgOSHAEoiZQu7a7qI6E27yThmP0Qn/NIO8cnyiPt1hgTdW1cUF/xWlknE3auR2mK6BNki/mtT8HWXdd+UiFvnxBYWHLPXFx5ilo8Ivhartrh2HdL54TdOiS0iXCLuXDbt1G41EbcvmPXbn2Oz3Ztv2vjfRbPTenWZu1fuLRMRap9u1mOLkIi7l/99P+4FUrzT5hAvv7QSfvVAjF5zSqDdYDTD49bNII/Lzvzxa2n+dOdI01cvWWD+1mnUQubPmBppfvDdO3L75o1Yt+31D76WD6fMlonTF8iUP9fIhlVLZeGsaU7LNH2io5l25/atWK8fAAAAQPLmm9ANgHu20JsSfn7LvfsRYWK7e0l8MpcQv3wNotxlGtSw3b0i3unzuqwsTEIO/2ECKCJeJhjjV7CpU5ZK6KmVJnvFK3UWsYVcF6/UWcW/UHPx8k19L/ASdEwkItTeJp8sJf5bt3YZCg4S8fI2y/oVbBZtBkzY+S0Sdn6jePlnMIEJL//05jlePv4e22J1HQo7u06802Q32/PySyfeBZtK2IUt99oRESzi5SveabKKd9qcJigSqtkzEWEivgFiu3tVfAMriG/Oqv/tO7PMIrNvvFJluLeP8tUXnwwFJfzybvM6I64fFdut8yLefuKfLo95nu5rnS7ZyqToQzkkOFhe6dNeTp84Kj4+PqYuyhsffivV6zWKsvbJ4X27pFLNepHmzZvxowlkVKvbUEa80E1eHPG2pE2X4b/nnjkp/do2kgZNW0uLtl2lXOUasW5vrrz5JX3GTHL96r1aQZaylWtISEiIbNuwJlJmDAAAAICUjQBKIuWdJpv4F23jlOERfOA38U6fT3wyFXH7HNvtC/cCB6kyOc8Iu3MvCFGktXkYemathJ5cKt6PdBUvb18Jv3pQwq/sFf/iT5vtaoZGyKFZJkihARvvgEDxDawkoWfWOLUp7PIes27v9PnFt3C5e+s+vVrCzqyJMoCi2wo7u178irQUn/T57k0LOiESHizi4++xLY6vyTtdbvHN0cplH5wX/6JPine6XPce28Il9Mg88cn6iOlyozTrJeTADPEKyGHaqdkrWjfGKyCn+BdvL17ePveybv6t+eKX/zEJv37MPN8nczGn7XmlyUYGiqkzckXyFSoq47/51eyXbz96S94dMVCm/bVJUqcJiHQc7Nu5VXz9/CR/Ief9eeHsadm8doW8+NrbZn1Zs+eQpfNmS6sOPezL5C1QREaM/8JkimjNktz5CkqLp7tIkzYdzPJR2bl5vWTMnMUEe/5Zeq87WqNWbZ2W8fdPJfkLF5O9OzYTQAEAAADghC48iZxmlZiuLMFXxTt1Zom4FfWoN7awOyK+qdzM8RLfnPeCB8o3R2UTgNC6Jir8yj7xyVTUBCzM0r6pxSd7RQm/st90a4mWt5/4ZCv738MMBcR295opZutO+OU94p25iD14ojSIoVkosWqLl7f4BFaI3Jx0ue3BE6WvUYNPGiwJv3H6XncffZw6i0TcuFe8NEJH0wm5IX556pjgiX27mQpH/9p1OZ9UJvjDaDwiPV94xb5fuvYbLDeuX5ONa5a53W/Xr16S9BkymWK8jubP/EnKVqphghg67/G2XU1GiiPNcKnb6HF56/Of5LflO6Vlu+6yaM4v0v7RcqauiQZHtECtq9+nTTI1UKZ/+4msXDxX6jVu6TbgkiFjJrl6mUKyAAAAAJyRgZJIadeUkCPzTb0Pr1QZxcvbz2ROePtG/jXfztv3XjcVV76p713o/8t0ldGuLKZLz71taeDBaVWpM5tuKxJ2W8QvbdTb9EntdBHs5aUBiAjTNUeDHO5el0/6PNG+7hi1xTfg32258EvnvD6tsaIj5vzb9cixnV4+97oEaTch8U0jXn7R7Nuo6P728nbflhQkQ6YspkuMRbNOsufIJefcjLCj/FOlNrVMHEVERMiCWdOkzmPNzWg5KjBnHpOtcnj/bilSonSk9WTJFigdnn3B3Pbt3CLfTRwvr/XvIm06PSODR70fqQaKrk9pDZX+nZrJR2NfkVff/tRpueC7dyV16jQPsDcAAAAAJEcEUBKp0LPrxMs/nfiXaC9e/wYidCQYkagzQrz8M97LhggPsdcTMRwKojpOswdVfPwjFZa1P3YIvMQJb7/oR62JcVucMxeinO7tZ/aZdhmKMsihy4SHmAwX14yImNSqMfs9hdOiq6777/atm5Iu/X+1SxzlKVDYzL8RdF3SZ7i3/zb/s8J0BTp6aJ+5WXLlLWCKyb44YpzbdWkgRjNKNPiybf1qKV2hqtRq2Dza9gakS2+66CycNT3SvAvnTkuTAu1j/NoBAAAApAwEUBIp7Wai3Vys4Mm9UWvOive/xUvd0VFhtAaKjhrjVIMkIsx0A7IyO8yoMuHB4hUQeO95ATkkIui4SO6a/z0l6Jipm6I1Uu4t5Hsvq+QBaftNMdZcNf57bbpeLSbr7RuztsRye6Kj61w9KD5ZStqnm+5AERpoSvXvMuFmOz4ZC/23jGMgyrz+yN1CdF9GKtqbAoWGBMvW9aukUo17RWE1G+T61ctSomwlt8s/UraSpA5IK7u3bpAa9RubadpVp0GzNpEyQlYvmS/jXxso/YaONjVKLLu3bTQBkKXzZ5mMlsat28ugke9IgSL/Fjj24NL5s05ZM9YoQjrdeh0AAAAAYCGAkkhp8CTs0k7TJUXrcoRd3C4S7iaTxIEGGLTIacS1Q84BFC9vCTn+9791ULwk7NwG8c5c4l7XmH9rogRfPSghRxfee/7tC2bkGb9Cj/+3ijRZTZZG2MUd4pU6870RdO6D2db1oxJyaI74Zi1lgidaNFYLtWpXpZi0JTa8U2UUnxxVJPTkclNPxjtAR+65aQq/mqKwGQveW0aL5B5fLLYclcUrldaaOWP2m1/uWvfWYxWL1a4+GuhJl8cM2az1U/yLPS0pnZ+fv7z72kDp3v//TI2SKZ++Kw1bPCWFi7sfUtvP318at2wryxb8bgIoOhrOmiULZPTHkyMtW7X2oxISEiyrFs+Txx5/Si5fPG+Kx546fkSq1WloAi61Hm1mitJGxyoiGxoSYoIvS+bNkpdeH++0jLanTMVqpgYLAAAAADxwAOXmzZvy/vvvS6lSpaR9++SZ6n7kyBH54YcfZPTo0QmyfR8t9Orjf2+IXC2YmrX0vZFqIsKjf15gRQk5OFN8w2qKl6nrkVa8MxUV32xlTYFWrami932yl7c/R5fxL95Owi/tMEVetRaIf5E2TrVIdGQfv4JNJPzaYZHrR80wxmbdDgVb7zVAMzrymroj7ui6U5VobwIx4dcOiZdvgPjlqW2CGDFti9vtmlopWdxu1y9XtXvDGV87KOGXL5ouN35565nRhezL5K5psl/Crx8SuX3BbM+xOK4uH3Zhq4Rf3KFFZMwwxhr40UCKBmVSsmyBuaRu45bSrudzphvNhbNnpHWHHtLumf7RPq9DrwHyXLtGcuXSBTm4Z4dUqFZbqtSKPEx3qtRp5MmuveXEkYPmcXh4mDRu3U6aPdlJsudwrpfjTsZMWcxwyVYxWg32BObKKx9MmikVa9S1L6eFZ+f++oP0H/a/+9gLAAAAAJI7L5vHYVYi+/bbb6V///6SLl06OXPmjKROfa8YZ3Ly999/S+PGjT2PQuMgKChIMmbMKKnK9nGuQfKQhV3YIl6+aU2QA/FDjwvNWPHNWdWeyRMXFv48VlKSX6d8LhkyZTbBkIS2Y/M6WTpvprz0xnuSFN26GSSPVykk169flwwZ7i9DDHD9PnsYx1OHuR3Y8UAi9UvLXxK6CQCQqM577isDRQMow4YNk6+//lpmzZolnTt3jlHWyh9//CEnT56UsmXLSvPmzZ0KTp47d07mzJkjV65ckXLlykmLFi2c5ms2SO7cuSVHjhyyePFiyZo1q/To0UPGjh1rtq8ZI1u2bJEaNWpIgwb3fsVeu3atrF692gR6dNojj0TuTrB+/XpZs2aNWaZ169aSM2dO0xbdnrIyUKpUqSItW7aUpMA30H3dCcQdPTb9CzZhlz6g9h6yVB6mcpVrmBsAAAAAuBN5nFkPdu/eLZs2bZJ+/frJM888Y4IpnuzatUtKlCghH374oZw/f14+++wz6datm32+BjqKFSsms2fPNsELXXezZs3MsKYWDWgMGDBAOnToYLJerMwQDaA88cQT8uabb8qNGzfsy/fq1csse/r0adm+fbvUqlVLvvrqK/t8fb62v0mTJuY1bd26VR577DHZt++/0T8AAAAAAADuKwNFAyaaHZInTx7p06ePjB8/Xg4fPixFihSJ8jkaLKlevbrMmDFDvL3vxWx27Nhhn6/dgdq1ayeTJ98rIDl06FATcPnxxx9NlolFAyT79+832SKOdNuavWKZNm2ayVLZuXOnScVRHTt2NO3W7WTJksUEZKZPny7btm2TkiXvjc6i2S937twxWSjdu3c324+uBkpwcLC5Oab+AAAAAACAFB5ACQkJkalTp9oDHYULF5aGDRuax2+99Zbb5xw9etQEKT799FN78ERpNx119uxZM/+LL76wz8ubN688/vjjsmDBAqcAinb7cQ2eKA2KONJAjXbx0W1qponeNJvl7t27JqhSv3590/VIu+RYwROlgZXYGDdunIwZMyZWzwEAAAAAAMm8C8/vv/9usjQ2bNhgMjP05uvrK999950ZwcKdCxcu2IMi7mh3HJUrl/OoKlrvRLvfOMqWLZvbdbhO16CMFrYNCwsz7bK6Ar3xxhumhorVrqjaFFPDhw83hWasm9Z3AQAAAAAAKTwDRbvvaG0SHx8f+zTtmrN582aTLeKuyGpg4L2hYk+dOiUFCxaMNF8DJVbQo0CBAvbp+li7Cd0P3aYGTqLrfqPLaJui4ljANiqpUqUyN0QWceuchAcdE7FFiE/GwmYYYUe28GAJv7xXbCHXxcs/g/hkeUS8fJPfaE6IHf1/u2bJfNmzfbP4+vlJhaq1pErtR2O9DAAAAAAkWAbK8ePHZcmSJfL222/bs0+s25NPPhllMdlChQpJ+fLl5aOPPnIqCmvVQNHMkwoVKjg9X7NS5s2bZ7rs3I+nn35aFi5caIrduo64YxWf1TbPnTtXDhw4YJ+v2TVW1otVO8WxMC1iJvTMWgk5/IcJnnj5pTOPw68dsc+3hd2VkP2/Svj1I+Lln17Crx+T4P2/ii30Nrs4BQsJCZaeLWvJ33NnSsbMWUyXvzFDesv7rw+O1TIAAAAAkKAZKFrnJH/+/CYY4kpHwdEhgHUEHS3A6koLtjZt2tQMMVy3bl1TCDZTpkymnor6/PPPzWg4GjgpXry4zJw5U2rXru00Uk9s6PN0+OJ69epJ27ZtTRcfrbOiNVB0umaXaG2Vv//+W6pVq2aW8fPzk1WrVpn6KapUqVKmu48OkVypUiWpWrVqkhnGOCGFBx2X8AtbxL/ok+Kd7l52kU+2siJh/wVHwi5sNYGsVEVai5e3r/hkKych+6ZL2IUt4penTgK2HgnJ29tH3vnqZ8mTv5B9WukKVeXVvh2k3TPPS4HCxWO0DAAAAAAkaAaK1gvRYYjd0eF/R44caYYodkcLxmrQ5MUXXzRdZ3Q4Yit4omrWrGkyQTQIo0GLL7/80mSQOBad1VFxGjVqFGndWtekaNGiTtM0QPL111/LmjVrTPAjX758MmrUKPnnn3/s69RltA2a6aIj/lSuXNlk2FhFZQMCAmTLli1m5B7HLkuIXvilXeKVNrc9eGLtay+/tPbHEUHHxCdjIRM8MfO9fcU7Y2GJuH6M3ZuCaT0lx8CIylfo3v/tq5cuxngZAAAAAEjQDBQdsjgq/v7+JkARnQwZMkSbUaJdeZ577rko52sAxR0NoESlYsWK5hYdzXTRmztan+X555+P9vlwFnHnkvhkLm7qn0QEnRDxSS0+GQuKd8C9WjjKFnxdvLI84vQ8r1QZxBYSZDJTYlJ/BinDn79+L2nTZ5Dipco90DIAAAAA8FBH4QE8Cg+RiOuHJez8VvHyzygSfldCDs6SsMu7zWxTg8YWLuLj7/Q0L299/O88QERW/T1Pfpn8mQx+4z0JSJf+vpcBAAAAgIc+Cg/gkQZGbDbxL9pavLz+7frk4y9hZ9aKb9bS97JLvP1MYMWRTR97edu79SBlW79qiYwd0kf6v/o/adSq7X0vAwAAAABxhatVxCnvNFlNAMUePNFpqbNKeHiw2MJDxcvHT7xSZxHb3atOz7PdvWKmAxtWLZXXB3SXvkNel7bd+933MgAAAAAQl+jCgzil9U8ibl8QW9gdp5F5vFJlNsGTe8sUk/DrR8UWcm+IaFvoLQm/dthMR8q2ac0yGTmgm/QZPFLa9Xz+vpcBAAAAgLhGBgrilHemYuJz45QE75su3unyii3kuthCbop/oeb2ZXyylZEIXebAb+KdNpdE3Dpnisz6ZIs8RDZSjqBrV2XEC90kfYaMcvTQPhk/cpB93uNtu5rhimOyDAAAAADEBwIoiFNa48Qvf0PxuX3RdMsR3zQmSGJln9xbxkf8CrUQ261zJsDim728eOkyjL6TovmnSiUvjhjndl6mLNlivAwAAAAAxAcCKIgX3gHZRfQWBQ2WeKXLpQNY8w7ASJ0mQFq26/bAywAAAABAfKAGCgAAAAAAgAcEUAAAAAAAADwggAIAAAAAAOABARQAAAAAAAAPCKAAAAAAAAB4QAAFAAAAAADAAwIoAAAAAAAAHhBAAQAAAAAA8IAACgAAAAAAgAcEUAAAAAAAADzw9bQAAABIPCIiImTBggWyfPlyady4sTRp0sRp/rZt22Tq1KmRnjd27FgJCAh4iC0FAABIXgigAACQRGzevFnatWsnJUqUkA0bNkjatGkjBVD27dsnX3zxhYwZM8ZpupeX10NuLQAAQPJCAAUAgCQia9assnTpUilYsKAULVo0yuXSpEkj//d///dQ2wYAAJDcEUABACCJ0MBJTAQHB8vbb79tuvuUL19eWrZsSQYKAADAAyKAAgBAMpM7d265evWqCaD06dNHihQpIosXL46yBooGXPRmCQoKMn/PnTsnt27dsk9PnTq1ZM6cWcLCwuTixYuR1pMrVy7z99KlSxIaGuo0L1OmTCYzRtdnrd+s83ZqifCOkJDUISI2kdR3Ukda7900d0W8RPyC/cQn3MdpXqhfqIT7hYt3mLf4h/g7zYvwipCQNCH27UR63amDxeZtc7veMN8wCfMPE+9wb/EPdl6vzcsmwWnu7a9Ud1KJl825e1RIqhCJ8IkQ3xBf8Q1zPtUK9wmX0FSh4hXhJanupor8WgPumr/+d/zF2+Zc6z/EP0QifCPEJ9RH/EL93K7X0z70v+sv3hHeMd+H1ntzP/vQL8zcPO7D26nESxvnuN5UwWLzsbndh9Z7424f2sQmwQHBD7YPI0RS343lPvQPlXDfcPEJ8xG/EOf1ejy+U981wzo8yPHtdh/++95Euw/DvSRVcNT78MKFCxIeHu40P0uWLJIqVSq5ceOG3Lx502lefHxGKH9/f5OBp59p58+fj7TewMBA8fHxkStXrjh9lqn06dNLunTp5M6dO3Lt2jWneb6+vpI9e3Zz/+zZs5HWmy1bNvHz8zPP0+c70i6UGTJkMNvT7Try9vaWHDlymPvaXm23u32or9PxM1bpPtB9oftH91NU+1D3r+5nd/tQ3xd9fxzp9nS7+n7q++pK26vtvnz5soSE3DuuLPo69fW624e6f3Q/RbUPdf/qftbvpLt3732+WfR90ffH3T7U91Pf16j2oR4Pely424f6XZcxY0a3+1C7s+bMmTPKfajHrx7H7vahdXxHtQ91vbp+d/tQ26Ptun37tly/ft3t8W2z2cz3blTHt7t9aB3fOl3nR3V863p1/e6Ob22Ptsvd8a2vQ19PVMf3hWTyGREbBFAAAEhG6tSpI7t27TInReqVV16R0qVLyzvvvGMKybozbty4SDVT1JQpU8zJjqVs2bLy1FNPmROXr7/+OtLyo0aNMn/nzJkjp06dcpr35JNPSrly5WT37t2mCK6lsBSWmxluyoliJ8xFaeG9hSOtd3+5/eYiMufJnJL+uvOJzrm85+RKjiuS9kZayXckn9O8O2nuyNFSR839gvsKRrqYPlzqsLmIz3Y2m2S+nNlp3qWcl+RCngsmaFDwQMFIF7UHyx009/MfzB/pQvxY8WNyO/1tyXIxi2Q7d+/CwnI161U5W/CsCSi4vla9IN5XaZ+5n+doHklzJ43T/JOFT8qNzDck45WMkvPUvQsAy42MN+Rk0ZPmAt7dPtxXYZ8J6ug+TBeUzmne2Xxn5WrgVbNv8xzL4zTvdtrbcqzkMXPf3XoPlj4ooalDJfuZ7JLpSianeRdzXZSLuS9KmptppMChApGCTIfKHDL3CxwsEOkC/2iJo3In3R3Jej6rZL2Q1WnelexX5Fz+cyZ44tqmcO9w2V9xv7mf90jeSIGQE0VOyM1MNyXTpUyS48y9CwBLUKYgOVXklGmLu9e6t+JeE/jJdTyXpL2Z1mnemQJn5Fq2a5L+WnrJfTy307xb6W7J8RLHTaDN3XoPlD1gghk5TuWQDNcyOM07n/u8XM51WQJuBkj+w/kjBV6OlD5i7hfcX1B8IpyDL0ceOWICcnoM6rHo6HLgZTmf77wJ6BTaXyhScOVA+QPm/s8//xzpoqxLly6mC6HWZFqxYoXTvPj4jFAaBO7atau5oHK3Xu2yqBd8ixYtkgMH7rXdonWiatasKUeOHJEZM2ZEuuDt16+fuT9p0qRIF4LPP/+8ufBauXKlbN261Wle7dq1pVGjRiZo8P3330e6IBsyZIi5/9NPP0W6EO/Ro4fJKNRaVmvWrHGaV7FiRWndurXZ766vVS8AR44cae7PmjUr0sV227Ztzef9zp075a+//nKaV7x4cenUqZO50Ha3D4cNG2YuenXfHz582Gle8+bNpVq1anLw4EGZPXu207y8efNKr169zH13633xxRfNBfWyZctMuxzVr19fGjRoICdPnjT7yZFeZA8cONDc/+GHHyJd4D/77LOSL18+Wbt2raxbt85pXpUqVeTxxx83F+GubdIL7eHDh5v7v/32W6SL+I4dO5o6Y/p+a5dZR6VKlTJ1yPQC3t1rHTFihAla/Pnnn3L8+HGnea1atZJKlSqZOmU631GBAgWkZ8+e5vhzt97BgwebYMbff/8te/bscZrXsGFDqVu3rtme/n91pMGT/v3727/PXYM6ffv2NQGL1atXy6ZNm5zm1ahRQ5o2bWqCEZMnT3aaFxAQIEOHDk1WnxH6/yamvGyuoSjcNz0QNLqYqmwf8fJx/pUAiImFP7u/uAE8uXUzSB6vUsj8iqBfskj+9ORETxZGjx7tcdlu3bqZExE9gY1pBoqemO7fv9/pl5n4+OVo2KphZKA4IAPl32OSDJREkYHyabVPk8Wvy2SgkIFiIQPlP2Sg/PcZoZ8teh0fk/NoAihxiAAKHhQBFNwvAigpT2wCKPqro/469c8//8Tq++xhBOQ6zO0Qr+sHcP9+afkLuw9AshcUi/Me51xWAACQpGmquWNy6aFDh2TevHnSuHHjBG0XAABAUkcNFAAAkgjtZ/zWW2+Z+1rUTfu4awq99v3VvvpK+/cOGDBAqlatavq6//HHH6af/quvvprArQcAAEjaCKAAAJBEaB9/a/QALVbnWJPAogEWLei3atUqe+E0LUoIAACAB0MABQCAJEL75WpAxJPChQubGwAAAOIONVAAAAAAAAA8IIACAAAAAADgAQEUAAAAAAAADwigAAAAAAAAeEAABQAAAAAAwAMCKAAAAAAAAB4QQAEAAAAAAPCAAAoAAAAAAIAHBFAAAAAAAAA8IIACAAAAAADgAQEUAAAAAAAADwigAAAAAAAAeEAABQAAAAAAwAMCKAAAAAAAAB4QQAEAIJ6FhIRIRERErOcBAAAg8SCAAgBAPGvSpImsXLky1vMAAACQeBBAAQAgAQUHB0uaNGl4DwAAABI534RuAAAAydWMGTPk1KlT5qb3t23b5jT/zJkzsmPHDilSpEiCtREAAAAxQwAFAIB4Mm/ePNm4caOcPXvW3E+bNq19nre3twQGBsrkyZMlW7ZsvAcAAACJHAEUAADiyZQpU8zfl156SXr27CkVKlRgXwMAACRRBFAAAIhnH330EfsYAAAgiSOAAgDAQ7B37175888/5dy5c5GGLR4wYIAULVqU9wEAACARI4ACAEA8W7ZsmTRu3FgeeeQRyZ8/v3h5eTnNv3PnDu8BAABAIkcABQCAePb111/L0KFDZdy4cexrAACAJMo7oRsAAEByFxISInXr1k3oZgAAAOABEEABACCe1a5d23TjAQAAQNJFFx4AAOJZgQIFZPTo0XL27FmpXr26+Pn5Oc1v3bq15M6dm/cBAAAgESOAAgBAPJs1a5YEBgbKunXrzM1VxYoVCaAAAAAkcgRQAACIZz/99BP7GAAAIImjBgoAAAAAAIAHZKAAABDPfvzxRzl+/HiU87t162bqpAAAACDxIoACAEA8W7t2rWzZssVp2vnz5+XYsWNSrFgxadGiBQEUAACARI4ACgAA8ezzzz93O33q1KkyefJkqVSpEu8BAABAIkcNFAAAEkjXrl1NJsrJkyd5DwAAABI5AigAACQQm80mISEhcvHiRd4DAACARI4uPAAAxLMVK1ZECpLcuXNH5s6dK0FBQVKyZEneAwAAgESOAEo8OLH8fcmQIUN8rBrJ3N3Q8IRuApKooCCvhG4CovHee+/J6tWrnaYFBARImTJlZN68eeY+AAAAEjcCKAAAxDPNNAEAAEDSRg0UAAAAAAAAD8hAAQDgIQgPD5eff/5ZNmzYINevX5fChQtLly5dpEiRIux/AACAJIAMFAAA4pkGTKpXry59+vSRHTt2yNWrV+Wnn36SUqVKyZQpU9j/AAAASQAZKAAAxLMJEyaYv8ePH5fs2bPbp0+ePFkGDRok7du3l7Rp0/I+AAAAJGJkoAAAEM/Wr18vw4YNcwqeqGeffVby5csnu3bt4j0AAABI5AigAAAQz9KkSSMXL16MND0sLMx052EYYwAAgMSPAAoAAPHsySeflBEjRsgvv/wiQUFBpqDsvn37pHPnzpIuXTopXbo07wEAAEAiRw0UAADiWbdu3eTIkSPSs2dPuXv3rnh7e0tERIRUrlxZZs+ebR4DAAAgcSOAAgDAQzBq1Ch54YUXzCg81jDG5cqVEy8vL/Y/AABAEkAABQCAhyRbtmzSsGFD9jcAAEASRM4wAADx5M6dO1K9enWTceLOu+++K59//jn7HwAAIAkggAIAQDz5/vvvpVq1apIxY0a387UmyjvvvGPqoQAAACBxI4ACAEA8WbdunQmgRCVHjhzi6+srJ0+ejNV6L1++LPPmzZMDBw5EuYyuc/HixbJ3795YrRsAAADuEUABACCenD171gRJoqPzz5w5E6P1nThxQrp37y5ly5aVdu3aybRp09wu98orr0iJEiVk9OjRUrNmTWndurUEBwff12sAAADAPQRQAACIJ4GBgbJ///4o52vXnUOHDnkMsljOnz8vjRo1MkMi586d2+0yc+bMkQkTJsjy5ctlzZo1snv3blm/fr2ptwIAAID7RwAFAIB40qRJE/nkk0+iLCKrBWQzZ85shjSOiapVq5oMlNSpU0e5zA8//CCPPvqovetQnjx5pGvXrmY6AAAA7h8BFAAA4knHjh0lQ4YMUqZMGfnss89k7dq1smfPHpk/f7507txZBg0aJO+9916cbnP79u1Svnx5p2kVKlSQw4cPy61bt9w+R7v3BAUFOd0AAADgzNflMQAAiCN+fn6yaNEi6devn7z44otis9ns83LlyiXTp0+XNm3axOn+vnbtmmTJksVpWtasWe3z0qZNG+k548aNkzFjxsRpOwAAAJIbAigAAMSjbNmyycyZM01B2W3btsmdO3ckb968UqlSJTMCT1zz9/eX27dvO02zHus8d4YPHy5DhgyxP9YMlHz58sV52wAAAJIyAigAADwEmnGit/hWqFAhOXXqVKQhjdOlS2eCOe6kSpXK3AAAABA1aqAAAJCMNGvWTBYsWCB37961T9MMmKZNm4qXl1eCtg0AACApIwMFAIAkQrv/LFmyxN4t58CBAzJ37lxT46RmzZpmutZamTJlirRs2VJ69OghixcvNoVlv/766wRuPQAAQNJGAAUAgCTixo0b8uWXX5r7WkNFa5Xo47Jly9oDKJkyZZL169fLRx99JL///rsZxnjTpk1SokSJBG49AABA0kYABQCAJCIwMNBknHiSPXt2eeuttx5KmwAAAFIKaqAAAAAAAAB4QAAFAAAAAADAAwIoAAAAAAAAHhBAAQAAAAAA8IAACgAAAAAAgAcEUAAAAAAASZaOUFe1alUJCAiQDBkySOPGjWXr1q0J3SwkQwRQAAAAAABJ0qFDh+Spp56SVq1ayaVLl+TIkSOSLVs2adq0qYSFhSV085DMEEABAAAAACRJu3fvltDQUBk4cKDJQNHgSd++feXixYty5syZhG4ekhkCKAAAAACAJKlevXqSL18++eCDD+Tq1asmaPL5559LgwYNzHQgLhFAAQAAAAAkSZkzZ5aZM2fKpEmTJEuWLJInTx45ePCgTJs2Tby8vBK6eUhmCKAAAAAAAJKkAwcOSKNGjeT555+XGzduyIULF6RMmTJSv359uX37dkI3D8kMARQAAAAAQJL0/fffS8aMGeX111+XdOnSSfbs2eWTTz4xWSjz589P6OYhmSGAAgAAAABIkvz8/MRmszlNi4iIsM8D4hIBFAAAAABAktSmTRs5d+6cjBw50gxjfPLkSenfv78EBgZK3bp1E7p5SGYIoAAAAAAAkqSKFSvK3LlzZfny5VK8eHGpWrWqqX3y119/maKyQFzyjdO1AQAAAADwEDVt2tTcgPhGBgoAAAAAAIAHBFAAAAAAAAA8oAsPAAAAgBTr6NNtE7oJAKJQaOYMSUzIQAEAAAAAAPCAAAoAAAAAAIAHBFAAAAAAAAA8IIACAAAAAADgAQEUAAAAAAAADwigAAAAAAAAeEAABQAAAAAAwAMCKAAAAAAAAB4QQAEAAAAAAPCAAAoAAAAAAIAHBFAAAAAAAAA8IICCB/Ld5Ely7OjRRLEXf589S7Zu2ZLQzUgSrl+/LhPef9f8jc6e3btk1oxfzf2zZ86Y54SGhsZ5e+Jz3YnFyuVLZcWyJQndDAAAAAD3iQAK7tvyZUtl/LtvS568ec3jZUuXyHvj3zG39997V7756ktZt3ZtnO3hsLAw+eD98fLbr7+4ne/j4yO9n+1ulkP0rl+7KmPfGGH+RiUiIkIG9Ottf3zq1AnznODg4AfavRcvXDDBkjt37sT5uhOzbNkDpc8z3eTa1aj3OQAAAIDEiwAK7tvoN0bKiwMHi5+fn3k8b+6fMvHjCXL92jVzkbhl8yZ5snUL6dq5g9hstgfe07r+0a+PkOf6PCtBQUGR5rdq3cZkMPz2y88PvC2IzPtjjly5clmefLpdnO6Oc2fPmGDJ7Vu3UtRuLlW6jJSvUEm+/OyThG4KAAAAgPvgez9PQvIUEhIify1aKEePHJGSjzwijRo3ES8vL7fL7ti+XTZt3CCz5sx1mp4zZy558+137I+feOppeaJVCxn5+mizTrV71y7JmCmT5P03cyWmvp8ySfr0e14WzJ8rv/48XXr37RdpmQ4dO8u333wlnbp0jdW6kzsNYC1aME9OHD8mRYoWMzdPJn/7pbTr0CnSMRAWGmrWdezoESlR8hFp0LBRpOeu/We1bNuyWdKlSy+NmzaXnLlymek3btyQn3783tz/6vNPJU1AgBQvXlICc+Yw08LDw+XvvxbKkcOHpXCRItKoSbMo2/fDlElSvkJFKV+xknms3WO2btksLzgE9b6Y+LE0adZCAgLSys/TfpR+/V806z9+7Ki0eaqt5M9fQO7evSsL58+V06dOSr78BaRZi5bi7+9v386aVSvk3LlzUr9BQ1m5YplcvXJFatWpK4+UKu3UHg0azv3jd5MBVaVadQkNCTFdoLp072lfpl3HzjLqtVfl1RFvRPl/CwAAAEDiRAYKjOPHj0vVSuVkxPBX5NDBAzLxk4+kY/uno9w7ixYtkNKly0iWLFmi3YOpU6e2d6+xrFi+TEoUKWACK7NnzYxR3YvTp0+b4E7vPv3kmWd7y5TJ37pdrl79BrJu7T9y7do13lkHz3TtKAP795U9u3fLRx+Ml+6d2ke7f27fvi3/rF4ltevWizSvdfPG8u1XX8junTulR5cOMmTgC07z+/d9Vrq0f0r27dkjc2bNkMplS5j6H1Yg5+aNG+a+ZhFdv35Nbt3+LxPlycebyneTvpH9+/ZK32e7y8uDBkTZxhXLl8qUb7+2P37/3bdlzOuvyZbNG83jkydPyGuvvCy+vr72LkItGjWQ6VN/kEuXLppAkHYnqlu9kowf96YJ2rw15g2pX7OKCZJYFv+1UEaNGCYtGjeQlcuWmoBKg1pV5a+F8+3LnDp1UmpVKW/2y84d26Vnlw7yYv++8uVnnzq1uU7d+nLu3FnZuX0bxycAAACQxJCBAqN/v96SI0dO+XP+IkmVKpWZtnnTpij3jl48Fy1ePNL0CxcvmBoo6srlyzL3zzny8tBXpZjDsv0HvCiVKleRH7+fYrrj6PY6dekmPZ/pJY+UKuV2e7ps1WrVpVTp0pIla1b535hRJgumXPnyTssVK17C1O7QLJfaderw7moAYNECmT/3D1m/dZcUKlzE7JNnu3eWnTuivog/dGC/yUgqUizye6zZF++8P8Hc7/Fsb2ncoLZ07d5TKlWparI7fp3+k6xav8WeofHKkEEmyLJuy07JkCGD9Os/QH768TsZOmyEZM2WzSyzccM687dD5y4mS0S1aNlK2j/ZSt4Y86bJWHKlwYjPPrnXDq2dsmnDeqn/aENZvXKFVK9RS1avWC558+WXAgULyYUL581yLds8If/36mv2dQx+sb+kSRMgfy1fbYJ9t27dkkdrV5P33nlT3h7/oX25SxcvyOoNW6Xov/tDX8/Ejz802S3q3TfHmlpA8/9eYbJftDhvjYplTN0TR7nz5JG0adPKrp07pFyFihyfAAAAQBJCBgrk6tWrpgDswJeG2IMnqnKVKlHunWvXrkqG9BkiTY8IDzc1UPR26+ZNE8y4ERQUKcukRs2a8tmXX8uxU+fk3fc+lB3bt0mVimWlQd1aZmQfzYCwaNbCD99PkWd79TGPc+bMaS6uv5syKdL2M2bMaP5evfpfBkFKt2jBfKlX/1F78EQ98+++jO79Ve7e4+7P9LLfr1y1mpQrX9GejfHXwgUma8Wxe0uf5/rL4UMHTWaTJ22ebGu/r/VC9Pg5ceK422Xr1Ktv1nvm9GnZtGGd5MqdRzp06iqrVy438zWQoss40i5JjrTdXXv0tGdKaXCjc7ce5nU4KlO2nD14cq9tFeX4sWP2xxo46tS1h73rkB6HT0RROyZDhowcnwAAAEASRAYKTDcGDVLky5c/xnsjQ8aMEnQjciFX1xooFy5ckFLFC0vpMmWl73PPR1o+TZo0pl6J3rZs3ixdO7eX5/v1Nlkmrds8YR/tR+uyHD16xJ7dot0yfp42Vd5+Z7z94ldZxWUzuclYSKm0aGuOnPdqkFhy5sod7XP0Il/pe+ya/ZEz0rpyybmzZ839M6dPRVq3BjaseSUfcZ9hZEmXPr39vhWM0K427mi2kbZl1crlcuzIYZORUqd+A3l50Asme2b1qhXyyvCRTs/Jmi27/b4e87pv3LVX2xpVu6y2We3S9WiGi+t+yZEzp9t239B9mpHjEwAAAEhqyECBvRvF2bNnYrw3SpUqLYcPHvS4XGBgoBQqVFg2bljvdr4WDV0wf5506tBWHq1XyxTvfPvd90wtE4tmmtSuU9dcFFvZLbpOLUA65/fZTus7fOiQKc7p6UI9JQnMkVMuXrzgNM3q0hKVosVLmCDVkUOR32PXdV28cF4Cc9wrAquBGn3stK3z5+zz4lqtuvVkzcoVJliiwRMNAmYPzCFzZs80BXNdM1Ac6XESGJhDLpyP3N7YtFXXky1b9kj7Rbv9uNJt3bx5M1IBWgAAAACJHwEUSNasWaVW7Try5ecTTZcJy/59+6LcO481aiK7du30WKxVuwcdP35MChQs6DRd1z1i+KtStFA+6da5g+kqsuCvpbJt514ZPOT/7Bkk+vw/fp8tI98YbTJbHG/tO3SS71yKya5ZvdLUV8n2b1AIIo82bCSrViwzXV0s03/8Idpdky5dOqlavYYpJOtKR7Ox6CgzOvJNg8ca2Y+LNatWmlFuLFO/n2JqkWjGiJW9pByLx94vzTpZtvRv2bxxg7lvTXtv3Jv2+ifRadioifw6faoJ5Cntavbr9Gny6GONY9WO+g0fkxm/TrcP133nzh1z3Lr6Z80qE7CsUKlyrNYPAAAAIOHRhQfG519+I82bPib1ateQho81kmPHjkrQ9evy+5//jTTiqGq1alKuXHn57ZefpU+/59wWkdXn/zFntuni0X/AQPsyk775Wgb07yfVqteQN0aNlXYdOpoLdnemTf1RAgICpI6b0WBatX5CPp7wgeneU6hwYTPtl+nTZMDAl3hXHWjh1Bq1akvThnXlqXbtTebQvr17PO6jZ3r3k3feHCPDXx/tNH3unN/l5IkTkit3bvll2lRT66NW7bpmXotWrc2wxc0fqy9tO3YyQZs/f58l30/71T40sBXYeHngC1Kzdh0pUeIR+zDGsaUZJkMG9jfDMmuBVmvatKnfS8cu3Tw+f8SosaYIbvNG9U3gRYdCDgq6LsNGvBGrdgwfOUoeq1dTWjdvJFWr1ZDFixaabj7e3s4x6hm/TJduPZ91GpUKAAAAQArNQFm8eLG0bNlSZs6cGderRjwqUbKkbN+1T/r2e95c6LZ54imZ+fuf0T5n5KgxMvHTj+y/3mvgpUvX7vZuNhoUGTXmTdm8bZfTcMcVK1WWLdt3y4rVa+WZXr2jDJ4onffO+A9MdxJXWoj2lWGvyblz97qILPl7sdwNviudu3q+cE5JtIvJb7/PM8GCtAFp5al2HWT+4uUy6OWh9lon7jz5dDtJlTq1zP/zD3ttEH3O4uVrzOgz6dKmk3c/+Fi+/W6q0/N+/HmGfPDJZxKQJsAUW127eYc0a9HSPl+DBwuXrJRGTZqaIY01E8VatxVkUbptnRZddxrNatE6J8NGjnLKKtHn6QhBFnfrVxp0+WfTdunSrac5xnr26itrNm6zd0lSGlh5ul1Hp+eVKl1GevX7r6aPFuhds2GbNG3+uKkZM37Cx9L6yackY6b/9q8WvF23do30H0CADwAAAEiKvGxWznkcadasmWzatEkKFSokGzdulJREC5jq6BvnL183w7WmBB9P+FBatW4jhYv8N8JLQpk+7ScpUKCg1KpdW5Kqu6H3glGJxZZNG2Xvnt3SpXvPhG5KoqajRmkwyAq8aL2eutUrScvWT8jrY960j9QTEhJqRpCKr8+fAjmzmCGUU8rnD+L/++xhHE8d5naI1/UDuH+/tPwlRey+o0//NwoggMSl0MwZieq8J04zUE6cOGEyUKZPny5bt26V7du3R7v8119/LW+//bb98YoVK0z2yvr1/xUcff311+XHH+/VXGjTpo2sWbPGPKdt27Yybdo0M/3y5csyZswYefrpp6VPnz6yfPm9YUwtGsh56qmn5OjRozJs2DDp2LGjvPnmm05D5aqTJ0/K4MGDzfz//e9/snnzZtOeu3fvxsn+SY4GDR6SKIInqlPnLkk6eJIYVapSleBJDGgW1hMtm8rgF/vL6NeHS/2aVUz3necHDLIv06hJs3gLngAAAACIf3EaQJkyZYrUqlVLGjduLC1atJBJkyZFu7zWtvjss8/sj7Xbz6JFi+SPP+51GdCCphMnTjTRIDVv3jxp3bq1XLx4Ubp06SJVqlQxQZDq1avL0qVL5YknnjCjvjRp0kR++eW/iPn58+dlzpw5pk158+Y1QZGffvpJunX7r6uHRptq1Kghe/bskVatWpnHjRo1MtsMCwuLy90EIJlJnz69zFu0VCpXqWq6Ng0dPlKW/7NRsmX/b9hkAAAAAElbnBWR1WCHBlA0c0P17dtXunfvLuPHj5fUqVO7fc6jjz4qZ86ckQMHDkjx4sVN5ogGNZYtW2bmb9u2zaTT1Kv3XwFRzQ6ZMGGC/fG7774rt27dMoEXaztaY+Hll1+Wdu3a2Ys4avs0oKMBHpU9e3YTUNFUe62LoIEcrYGgARP9qwEaDc588cUXUb7m4OBgc7NoWwGkTJmzZJGuPZ5J6GYAAAAASOwZKNp1R7M2tGuNat68uSkAOmvWrCifkydPHilSpIgJnGg3nH379snIkSNN1xkNiuj08uXL24e0VQ0aNHBax9q1a03dFccgzZNPPimnT582XXIsGlTRTBVL4cKFTVDFKkC6bt06adq0qVOx0scffzza1zxu3DiTHWPd8uXLF8O9BQAAAAAAUmQARbM7dNhOzfrQLjJar8TK+oiOBkQ040Trn1SsWNEENooVKyarV682ARTXgImmyju6evWqvYuPxQq4XLlyxT5NAyOOQ4fqyCRK26iuXbsWaT2uj10NHz7cBI2sm2PABgAAAAAAJB9x0oXn0qVLpsaIdoPJmTOnfbp2gencubMcOXLEBEbc0QDJ0KFDTZca7dJjTVuyZImsWrVKevf+byhSd3S0n0OHDjlNO3jwoH1eTBUoUMC005HrY1epUqUyN0Tv1KlT8slHH8q2rVtEB30qV76CDBr8suTPn59dByd6fKxYtkS+m/SNHD50SL6c9J2ULlM20l5avGiBTP7mK7l08YKUKVfBDGWcK3du9iYAAACAxJ2BoqPk5M6d2wQ7NPvEurVv394Uep08eXKUz9WgiXaj0RF1HAMo+hzX+ifudO3aVRYuXCgbNmwwj7UmyTvvvGO63zh2/fFEa6vMnTtXduzYYR5rF6JPP/00xs+HezqCUeOG9WTnju0yfMTrMvKN0bJ/3155rEEduXnzJrsNTl575WWZ8P67UqVaddm1c7vcvn0r0h5aOH+udG73pFSvWUtGjv6fnDxxXJo3qs/xBAAAACDxB1C0m46OgOOOTv/uu+/MMJ/R1UHRLjC1/x2CVgMo2v3Gtf6JOzpSzv/93/+Z59SpU0eKFi0qFy5ccBrdJyY04KJFb3Uknrp165qitto25VgXBbGzZ/duOXb0qIx/f4I82vAxqd/gUZnw8UQ5dfKk7Pw3WAVYNCAyZ/5iadGydZQ75e2xo6VTl+7y0suvSP1HH5PvfvrFZKL89MMUdiQgYkaO0wC16w0AAAAP5oEjAzqKjWZ8aP0SdzQrpUyZMnLnzh1TVNadn3/+WW7cuGGfny1bNjOqjnbrcaTDG1euXDnS83X7AwcOlN27d0vmzJmlUqVK9tF3VLVq1WT27NlOz9GMmT///FNy5Mhhn/bNN9+Y0XvOnj0rjzzyiOlCpMMjRzWKEDwrWqyYeT+XL1sqZcuVM9OWLvnbvE8lSpZkF8JJ2rRpo90jV69ckZ07tsnQYSPs0/Rzo3bd+rJi2VLp1/9F9ihSvBkzZkinTp0i/X86fvy4ZM2aNcXvHwAAgAQLoOgQwNpdJyp68RzdfKXdfFw1btw40jQddjgqGhDRmzuBgYFmVCBHAQEBkdqldVy0+G3JkiVNQEeHS9YRfnD/MmTIIIuXrpR2T7eRTz+ZYM/o0WlZsmRh1yJWTp26V6g5R67/ai2pXLlyy9Ytm9mbwL80UKL1yQAAAJAIR+FJDtasWSMFCxY0tVisorcffvhhQjcryddA6dv7GcmbN5988dW38tU3k6Vo0WJmmhYZBmIjLDTU/E3l71y82T9VKgkNuzcPgNhHmYuq+ywAAABij+IeDsaPHy+DBw+Wffv2mfonWk/FsSsQYm/WjN9k86aNcvr8ZXs9m6rVqkueHFnll+nT5Jle0Y+yBDjK8m/3gytXLjtN18dkNAH/uXr1qunepkGU0qVLy5tvvhkpExMAAACxQ3TARa5cuUwGihaRJXjy4LQ4sNaQyZgxo32antRrF6rrQdfjYAtISfIXKGiCKBqUc7Rpw3qpULFSgrULSEw0WK0j2Z0/f94UVW/durXpsrp69eoon6Mj2OnId443AAAAOCOAgnhVp249043ny8//GxVp8rffmMBKnTrRD1ENuPLy8pJuPZ+VKd9+LadPnTLTpn4/RU6dPCFduj/DDgNETO2uHj16SPr06U0dqlGjRkmtWrXk008/jXL/jBs3zgS6rVu+fPnYlwAAAC7owoN4pSPvfP7lNzJi+Cvy/nvvmAvg27duyScTv5AqVauy9+FkzuyZ8v47b0toaIh5/HzvZyRNmgB57oUXpUv3nmba8JGj5cTx41KpTHHJlj1QbtwIkolfTZJHSpVmbwJR0OLo27Zti3L/DB8+XIYMGWJ/rBkoBFEAAACcEUBBvOvxzLPSrUdPOXnypIjNJnnz5RMfHx/2PCKpW6+BFC5cJNL0nLn+G2ErVapUMvmHaXLp4kW5fPmSFChYiKHGAQ80eBJdQET/X+kNAAAAUSOAgodC68kUKFCAvY1oaX0Tq1CsJ9myZzc3AM60+06LFi1Mtx3tQjlhwgQTQNG/AAAAuH/UQAEAIBnRmicLFy6UevXqSZMmTeT06dOydu1aqVOnTkI3DQAAIEkjAwUAgGSkcOHCMmXKlIRuBgAAQLJDBgoAAAAAAIAHBFAAAAAAAAA8IIACAAAAAADgAQEUAAAAAAAADwigAAAAAAAAeEAABQAAAAAAwAMCKAAAAAAAAB4QQAEAAAAAAPCAAAoAAAAAAIAHBFAAAAAAAAA8IIACAAAAAADgAQEUAAAAAAAADwigAAAAAAAAeEAABQAAAAAAwAMCKAAAAAAAAB4QQAEAAAAAAPCAAAoAAAAAAIAHBFAAAAAAAAA8IIACAAAAAADgAQEUAAAAAAAADwigAAAAAAAAeEAABQAAAAAAwAMCKAAAAAAAAB4QQAEAAAAAAPCAAAoAAAAAAIAHBFAAAAAAAAA8IIACAAAAAADgAQEUAAAAAAAADwigAAAAAAAAeEAABQAAAAAAwAMCKAAAAAAAAB4QQAEAAAAAAPCAAAoAAAAAAIAHBFAAAAAAAAA8IIACAAAAAADgAQEUAAAAAAAADwigAAAAAAAAeEAABQAAAAAAwAMCKAAAAAAAAB4QQAEAAAAAAPCAAAoAAAAAAIAHBFAAAAAAAAA8IIACAAAAAADgAQEUAAAAAAAADwigAAAAAAAAeEAABQAAAAAAwAMCKAAAAAAAAB4QQAEAAAAAAPCAAAoAAAAAAIAHBFAAAAAAAAA8IIACAAAAAADgAQEUAACSmSNHjkjv3r2ldu3a0qFDB1m7dm1CNwkAACDJI4ACAEAycv78ealVq5bcuHFDRo8eLfnz55cGDRrIhg0bErppAAAASZpvQjcAAADEnY8//lj8/f1l2rRp4uPjI40bN5bt27fLmDFjZN68eexqAACA+0QGCgAAyciSJUukadOmJnhiadWqlSxbtkwiIiIStG0AAABJGRkocchms5m/N4KC4nK1SEHuhoYndBOQRN24EeT0OYSU68SJE9KsWTOnablz55Y7d+7IpUuXJDAwMNJzgoODzc1y/fp18zfoIXyfhd4OjfdtALg/D+MzIDG4EcrnEJBYPYzPIWsbMTmPJoASh7S/uSpaKF9crhYAYvU5lDFjRvZYChYaGiqpUqVympYmTRr7PHfGjRtnuvi4ypeP7zMgJZstsxO6CQBSuowZE9V5NAGUOKS/8J08eVLSp08vXl5ecbnqZEEje3oyrvsoQ4YMCd0cJDEcP9HTiLl+6OvnEFK2rFmzyuXLl52maeaJfi9lzpzZ7XOGDx8uQ4YMsT/Wrj5Xrlwx6+L7DDHF5zSAhMbnEOL7PJoAShzy9vaWvHnzxuUqkyUNnhBAAcdP3CPzBKpSpUqyceNGp52xfv16KVmypAQEBLjdSZqx4pq1kilTJnYo7gvf8wASGp9DiK/zaIrIAgCQjPTu3VvWrFkjf/31l3m8f/9+MyKPTgcAAMD9IwMFAIBk5LHHHpPx48dLmzZtTCrqqVOnpHv37jJo0KCEbhoAAECSRgAFD42mh48aNSpSmjjA8QPErZdffln69u0rx44dk1y5ckm2bNnYxYh3fM8DSGh8DiG+edkY8xIAAAAAACBa1EABAAAAAADwgAAKAAAAAACABwRQAAAAAAAAPKCIbAr0zDPPyM6dO819Ly8vyZ49u9StW1defPFFSZcunSQnv/76q7nNmDEjoZuSLL355pvy+++/24+lTJkyScWKFWXw4MGmcCUAAAAAJBcEUFKgvXv3SoECBWT48OGiNYR1lIZhw4bJunXrZM6cOZKcXLhwQXbt2pXQzUi29NgJCwuTb7/91jw+f/68vPXWW+Y42rNnj/j4+CR0EwEA8Wjx4sXy5JNPys2bN9nPAIBkjy48KZRmnVSpUkWqVq0q7dq1M0NeLliwwARUoqOZHE899ZTUr19fXnvtNacTpvDwcPn000+lcePGJqNFgzJXr151ev7jjz8uv/zyi5mny4wbN05OnTpl2vLPP/9Ijx49pGbNmvLXX3+Z5Y8fPy4DBgwwy+oJ2o8//hipTbrMoEGDpF69etKhQwdZs2aNma7reO+998x8Xb/epk+fHkd7EBbNWrL2r76/77zzjhw4cEAOHTrkdifp+6PHj3WsXbp0yTz33XfftS8zZcoU6dWrl7k/cOBA+fDDD83tsccek969e5vpt2/flv/973/SoEEDadiwoTmW7t69a19HSEiIWe/ff/8tQ4YMMcvo8bF161an9ugx+tJLL5ljrGvXrqZ9jz76qKxYsYI3GQA80O9+x89eAACSMwIokIiICFm7dq0UL17cdMOIyhtvvGEuajVQMXr0aMmQIYMMHTrUPl+DMG+//bb07NnTZLcsX75cGjVqZNZv2b59uzz77LPi5+dnLni7dOliTrw2b94sbdu2lTp16sjHH39sAjtHjhwxF8ABAQHmQrljx46mDXrfcvDgQalUqZKcPn3abFPXoYEdzYTQdegFc44cOeTLL780N70AR/zSAET69Okld+7cbueXLFlSVq1aJTt27DCP9TjZvXu3/Pzzz/ZlZs6cKZkzZzb3NRij76lmEo0cOdJ+zLVv394ExDT4oUG2SZMmmQCIRY87Pa46deokhQoVklGjRpl26TF57do1+3IamNNgyauvviqtWrUy61i5cmWk4B8AAAASr9DQUPPD2Q8//GA/zwTinA0pTvXq1W3Zs2e3Va5c2VapUiVbYGCgrWTJkrYDBw5E+ZxTp07ZfH19bT///LPT9Lt375q/J0+eNPPnzp1rn3f+/Hlb6tSpnZ6TJ08eW9euXZ3WcfDgQU1FsH377bdO03W57t27O01buHChLU2aNLawsDDzuGPHjrYaNWo4LaPzQkNDzf1PP/3UVqJEiRjvG8ROr169bOnSpTPHkt7y589vjqdly5ZF+7yyZcvaJkyYYO6/8MILtv79+9v8/Pxsly9ftoWHh9syZsxo+/PPP838pk2b2ipUqOD0/FWrVtm8vLxse/futU/bvHmzOY42bdpkHt+5c8c8fu+99+zLBAcHm+PHWvfy5ctt3t7etiNHjjgdY/q82bNnczgAgAcLFiyw+fj42KZOnWqrWLGiLVOmTLZHH33Utm/fPvYdgIdm//79tqJFi5pb586dbeXLl7cNGzaMdwBxjhooKZR2V9CMDXX27FnT7aJfv36mL7O7uhXavUbTdFu3bu00PVWqVPbMEp2v3XcsgYGBpqCoZgFoJohFu+i44zpdMxO0LTVq1DDdPfSm2Sp37tyREydOmKwCzRTQLh6OqLvxcBUpUsRk9yjN7Pjqq6/MsaSZKNmyZXP7HO12o++vZo/o3w8++EA2btxo3s+8efPKjRs3zDEa1bGhx1T+/PlNNotFM5G0a5rOq1y5sn26ZjFZ/P39zTKaoaS2bNkihQsXNseSRbvvRJeJBQBwpt//eh6h3WyzZMki//d//2e6dGrNNc04BYD4ppnqel6oWcx6vqf0HBOIawRQUngNFEuZMmXMheTcuXOlTZs2kZbXoIWeBKVOndrt+vSCV+dbH1iO9TF0niPtkuOO6/Rbt26ZLkOOwReLNcKLtiu5jRyUVGugWLS+iR5fGkgZMWJElAEUfW81kKHdsLTrlk5btmyZ5MuXzwTeMmbMGOWxocdU2rRp3bbF9Xjz9XX+mNPgiFV/RWv4uK5bj2HX4xgAEL1PPvlEKlSoYO5/8803kidPHpk9e7bpbgkA8Wnfvn2mxp3+oOd4DqfnlkBcI4ACw8oUsH6Zd6X1UbQop/6aVKpUqUjzixYtauYfPnzYZCRYNSj0A61Jkyb3tZeLFStmsmMcL87dtUuzX6Li7e3tsTAu4pYG0jT4EdWxZAVZrl+/burdaLaIBkP0S06LC2tmiacvPD3edAQgLSRrBUB0fVqQ2Dr+YkKDhrqe4OBgezbV0aNHzWMAQMxVq1bNfl+/A/SXYK1vBQDxTWshWud1QHyjiCyMr7/+2nR9iap7TfXq1U0XCR3tRi9UrdFTvvvuO3NfL4I1a0C7Bemwtuqjjz6SK1euSOfOne9rL2vXHC0Sqql4Fg2oaKFaS//+/U2hqCVLltinff/993Lx4kVzP2fOnOZCXoM7eDh0NKeTJ0+arJKoZM2a1WQ9TZw40XSZUdplRwNumm7pKYDSsmVLU8RYixkrDZJptou+382aNYtxW7VLmmaoaOq5lYb++uuvx/j5AID/frBwfexYRB4A4ot2HVTR/XgHxBUCKCnUrFmz7EPPas0JHUJWU27Lli3rdnnt9jBnzhwTiNCLVP1lqXz58qbOiTX/p59+kj179phRbwoUKGBG2dHgRlSjsXiiI/To0LV9+vQx69Cosv7CpWnBlu7du5uLaO12VLBgQdMevQC3un80bdrUvD6dxzDG8UMzgKxjSTNDdFhsHS3HU9q2Bkm0u40VLNERcjT9W7tlOdY/cUe76uioPRpg0+5ceps3b56ZFlU3M3d0mxoE1GCfdh3S9WhARdfh2vUHABA1rSnl2AV3//79TnWqACC+lCtXzpzv6w/CjrRmIhDXvLSSbJyvFYma/sqvtR+swIdGbfXiMaYXjGfOnJGgoCDTxcZdwVbtxqPFXrV7jWvxOB1STAMgmoFg0e4SO3fuNB9+7mpPaEaL1snQrhoamHFHt3fo0CHz4ZkpUyanefoLmHbT0GFp9XVaQR88uOPHj9uzfZQGrrQLjtUdJjr6PH2+4/uu3Wc0qKLTLPrep0mTxry3rvS91WGO9TjW49HxF1D9aNOCsnoC71gnR481DZQ4FrjVoI0et3p86X0NAupzNesKABC1hQsXSvPmzaVq1ary22+/me/gIUOGyKJFi8z3cmyC2gBwv3T4Yv1BVUsH1K5dW3bt2mWGNdYfeIG4RAAFQIqmXcQ040UDa5ph1bdvX5PFpAEVRnQCAM8BFO1WqTWtdEQ1/cVXs1knTZpEEBrAQ6U/zGl28oULF8znT6dOnTiXQ5wjgAIgRdP6OT179jSFbM+dO2cypKZOnWpq+gAAoqeZgPorr5V5qNl/DAUPAEiuCKAASPH0AuDIkSMmiGINkQ0AAAAAjgigAAAAAAAAeMAoPAAAAAAAAB4QQAEAAAAAAPCAAAoAAAAAIM5cvXpVli5dyh5FskMABQAAIInr2rWrzJs3L6GbAQDG0KFD5e+//460N7Ro/9y5c+XKlSvsKSRJBFAAAACSML0Y2bBhgzRr1izSCGO1a9eWKlWqSEhIiCRH+rpKliwpW7ZsSeimAPjXvn37ZNq0afJ///d/kfbJwIEDpVWrVvLpp5+yv5AkEUABAABIwt59913p27ev+Pj4OE1fuHCh7Nq1S44dOyZz5syR5EiDRPv375fbt28ndFMA/Ouzzz4zQZIsWbI47ZMzZ86Yz6UBAwbIlClTzP/f6Kxdu1YOHjxof3z06FETML5796592sqVK81n3J07d8w8/SzQ5f766y85ffq0fbnDhw+bafqZ6EqX1/XYbDY5cOCArFixQi5fvuy2Tdu2bZNVq1aZLkr6etxl2SB5YxhjAACAJErT4YsUKWIuAAoWLOg076mnnpKcOXNK6tSpZffu3bJo0SKP69Plxo8fLzt27JC8efOaNPx69erZ5y9fvlw++OADOX78uOTLl08GDx4sjRo1ss+fOHGiuejRbJhvv/3WpOnv3LlTunfvLmXKlJGbN2+aCyi9P3nyZJNB8uGHH5oLn9DQUKlcubK88cYbpt0WXeajjz4yy+j95s2by/Dhw8Xf318qVqxoLmjy588vadKkkeLFi8sff/wRZ/sXQOzpZ9Frr71mAruO3nrrLfnzzz9N0CFXrlwyc+ZMadKkSZTr0effuHFDpk+fbh737t1bJk2aZD5DmjZtaj4zMmXKZALERYsWlUKFCkn79u1l/fr1UqpUKXnllVekbt265vNHPxcqVKgge/fuNZ8/v//+u3mu0s8X/VwrXLiwCcBoYEcDN7NmzbJ/vgUHB0ubNm1k3bp1Uq5cOTO/atWqJvvv3LlzHCYpiQ0AAABJ0qRJk2zZs2ePNP38+fM2Pz8/29atW2179+61eXt7244fPx7tujZt2mQLCAiw9e3b17Z69Wrb3LlzbQ0aNLAFBQWZ+WvXrjXrHDVqlG39+vW2sWPH2nx9fW3Lly+3r0Pn6bQmTZrYVq5cadu3b5+ZXr9+fTP95Zdftm3cuNF24sQJM71ly5ZmG4sXLzbr7N27t61gwYK2mzdvmvkRERG2Zs2a2YoWLWr77bffbOvWrTPbeO+998z8nTt32vR09qeffjKv88iRI3G4dwHE1sWLF83/yTVr1jhN1//LhQsXtn377bfmcZ8+fWzt27ePdl36/zpnzpz2x0WKFLGVL1/eNmzYMPN41apV5jPp1q1btqNHj5rttm7d2hYSEmJ/zueff27LnDmz7dChQ+bxpUuXbMWLF7cNGjTIvsyECRPMc6dNm2af9vzzz9uqVq1qf/zRRx/ZAgMDbSdPnjSPz5w5Y8uTJ48tR44cHCQpDAEUAACAJOr111+3VahQIdL08ePH26pUqWJ/XLduXRN4iI4GKlq0aOE0LTw83NxU06ZNI13wdO7c2QRALLqNtGnT2q5du+a0nAZQ6tSp4zTt77//tqVLl85248YNp4ssvUj67rvvzOOFCxfafHx8THDEUWhoqPl7584dc+GjF1IAEt6ePXvM/0nX/7NLliyxpU+f3h4c1YCtv7+/CbhERYMU1rpOnTplS506tQmqVK9e3cz/3//+Z6tdu7a5bwVQli1b5rQOne8YLFETJ060Zc2a1SmA4hioUbNnzzafT5YaNWrYhg4d6rTMyJEjCaCkQNRAAQAASKK0S4ufn1+k6do9pk+fPvbH/fr181hzYM2aNfL44487TfP29jY3tXXrVmnYsKHT/MaNG5vpjkqUKCEZM2aMtP5q1ao5PdY6ApqCX6NGDSldurT9dvbsWVOHwGqTptVroVhHvr6+Ub4OAAknICDA/HWtS6Rd+rTL3bJly0x3PP1/njVrVvnxxx+jXJd28ylWrJh5jt70s0K77mjRaO3ao10KGzRo4PScPHnyOD3W7o3avceRdvXTGie6Dou2xZF2fdS6KhbttqifRY60+yRSHr59AAAAkiitFXLx4kWnaatXrzajYLzzzjumvojSQMWJEydk8eLF5gLEHe3jb138uKMXE1pnxJE+1oKOmtXs5eVln+aO63Rdn9YumTFjRqRlrYsZT20CkLjkzp3b/J/Vwq6VKlUy07Tg6uzZs6V+/fry5Zdf2pctUKCAqWmitZSiogESDZSkT59eHn30UfPZoAHVpUuXmnpLw4YNc1re+hyyZM6cWa5fv+40TR+nSpVK0qZNG+PXpfVSgoKCnKa5PkbKQAYKAABAElW9enXzy6gWa3X8pVcLKc6fP98UStTbvHnzpFevXmZeVDwNB6y/4mpBWEdabFZ/hXW9aIkJzVTRtmfLls1s2/GWPXt2e5sOHTrk9EuxI2vkIQ3gAEh4mhGnhVv/+ecf+7SpU6eazBAt/qrZJ9ZNP6N0FC0tzOopgOKYbaJ/tdi1BoZr1aoVbXtq1qxpCtc60s9EzYizsutiQrNftL2O9HPVUVhYmHldp06divF6kfQQQAEAAEii9CJAR8vR4TmVBhp+++036dSpU6SgRJcuXcxIFJcuXXK7roEDB5oAi7UuvTjRkSms4MXzzz9vfi3evn27eazDgeqvyTr9fmiQJzAwUJ599lm5du2aPSvl008/tXcLatu2rWTIkEH69+9vT6fXUXf0NVoXa/qLtKbpO9JhUnXkDQAPnwZr9f+o1WVQPzeeeOKJSMtpdoiO8qXzo6JZJxcuXDBDBmvA2AqgaIBGP/88ZajpqF46Yk67du1k2rRp8sILL5isNx3+PTZ05K9NmzZJt27dzKhA+rmlo/04Bo81I0WHb9ZhkJF8EUABAABIojQDQ4MF1gWIXiBoNoa7oUH1QkXT4H/44YcoL3rGjBljAhuaAaLBDR2e00pz1/nPPPOM+SVWf02uUqWKCcrcbwAlXbp0smTJEnPRodvSYZG1S9Lhw4fttQW0vRrQ0V+pNYVeayJoO7RWikVT+J977jlTK6F169Zm2ubNm83FGYCHT4dQ1//fOrywBj40yNu5c2e3y+rnhw5vHlUWmf6f79mzpwl8aLcbK4Ci9Zr088iigRSd5totRz9XNLNOh1a2ugtq4EMzUyxa20S7FznSzyTHmlD6+aJdhnQ7mmWiQyHr56W+TosOaazt1eGOkXx5aSXZhG4EAAAA7o/WIClVqpRJky9UqJCpG6IXC+5oHRQtwKp1CqKiaeiagq4XAtYFiyMtDqmBlRw5ckS6WNHsFp2vtU1ct6sXHtpdxx3NQNG6BHqxE1VavdZ60dNWvbBx1ya9UNOAkhaw1SKRWgcmqu0BiF8rV640XVxim+mRmGk2ngZ1HQNF+pljZcRpcFo/E59++ukEbCXiGwEUAACAJE5T3DWV3KodkpJpVx+tCeM6GgcAPAgr604z5RYsWCAzZ840owO5jjCG5I0ACgAAAAAA0dDuhV9//bUZYUiz/XSoeIYyTnkIoAAAAAAAAHhAEVkAAAAAAAAPCKAAAAAAAPAAQkJCZO/evezDZI4ACgAAAJKchQsXyquvvprQzQDwr6tXr8quXbvst6NHj5qgQnKkI4Lpa9QRwCw6Io+OzKOfTUi+qIECAACQjEREREiTJk3sj3XYYh2S+Mknn5TWrVtLchptp2jRovLLL79InTp1Ero5QIr37bffmsKqpUuXtg/7e/nyZRkyZIiMHTs22Q0fnyZNGlm1apXT548OJ//OO++Y4AqSJzJQAAAAklkAZcmSJVK1alUZNmyYDBo0SIoXLy5t27aViRMnSnKhFy89e/Y0FysAEgfNwrAyUI4fP24CnP/73/9k6dKlHp8bFhZmRrq5deuW2/k3b96UAwcOmMCMu6HcNeNFXbx4Ufbs2WPu6zSdp06cOGFG0HF07tw5OXnypMkoiYo+/9SpU07T9u3bZ1+/vtZDhw6Zx08//bTZjn4GI3kigAIAAJAM6a/AjRo1kubNm8vw4cNNavmsWbOiXH7kyJFmiE7LDz/8YJ6vF0GWrl27yl9//SXnz58387Zu3SovvfSStGjRwn7BoBcSL774opnWu3dv2bBhg9N2tA36K/W6deukf//+JjPmvffek9DQUKfltmzZYgIkekEybtw4WbBggbRv395pGX2s0/UiCEDi07hxY/Hy8jJBiujoZ0C2bNlMNkfevHnN50p4eLiZp3/1sc7Xzx39q58dGnCxfP755ybDrk2bNlKmTBnp3Lmzmf7MM89Iv379zOdhvXr15K233jLTNcBSpUoVKVWqlNSuXdtk6bl+Pu7evVuqVasmBQoUkJo1a0q5cuXsmSX6GaZGjRolHTt2lKFDh9oDu3Xr1o32sxZJGwEUAACAZE7rEOzfv18KFiwY5TL+/v7y448/2h9PmzZNVq5cKX///bd5rEGTn376SfLnz2+6z2jARIMkeuGhFzd6gaK/7upFiabt9+rVS9KnT28uiDTN3aK/zup6BgwYYC5cNLDz8ccfO9Uz0V939Xn6a3aXLl1MEEeDJdoeR2XLlpW0adPG6NdtAA+HlYGiQVL9f54jRw5p2rRptF1/NBDx22+/ydmzZ+XSpUvms0o/Z6z5GtDVYKx+fmhwVTNbNGjiut369eubz6pt27bZp2uQVdehn0/ffPONyXDR9rRr185sS9c5efJk6datmxw8eNA8R7NcNPhTokQJU9tFA0D6maifo8r6TNN26XZnz55t316lSpXkn3/+ieO9isTCN6EbAAAAgLinXVu+++478yutBiQqV64s77//fpTLN2jQwPw6q0URNZiyZs0akwGybNkyEwzRv3ohVLJkSXsavGa2DBw40L6OZ5991vyiqxcaSrNHNJiiXYl0fRZt09y5cyVnzpz21HzNMvnwww/NY72vv/hOmjTJPNYgi3Xh5Mjb21vy5MljT58HkLA0W0QzMpR+lmgwQ7vwWP/X3fnkk09MRocGLJQGTjUoa/nyyy9NNptmgCgN1j7//PNmuuPnjwZzBw8eHGn9TzzxhPk8scyYMcMEZzRbxQqIaMCmUKFCJthSrFgxE8wJCgoyQZrUqVObZTSzRW+eZM+enay4ZIwACgAAQDLUqlUreeyxx0xNFK0b8Oabb5pfX6MauaZGjRrmwkV/OU2XLp1kypTJXLRo8EItX77cBFkcaUq8o/Xr15uMEUeaVq/TtB0a8LAuVhwvqPSxYzcc/aVZgzGOmjVrFimAYqXMO46EASDha6BYNHirwQudrvWY3NEghhaajYoGSF0DI5p9pt1+tHaJdhFS2tXGuu9IAyOOdKhhDaBoXShXVldCbZMWqdYsutgKDg6WVKlSxfp5SBoIoAAAACTjGihKR+XRQMNzzz1ngiJZs2aNtLxmnWgQRTNN9KLh0UcfNVkrmsquae0aQHH8VVhpoMXRtWvXJEOGDE7TMmbMaLoQadq8dTGi23KkFz0aYLFcv3490oWL63otmuESGBgYw70C4GHSjDXNLPn555+jDKBohkd0QVDtpmd157Ho8gEBAU4BEw3SuOM6XT9/NJsuupFyPLUpOqdPn44UtEHyQQ0UAACAFEC7umjXmegKrmqGiQZQrGwTvfDQOiV68aO/yLpmoLgqXLiwyXZxpM/Too+x+SVXM1Jcu+W466ajARutTaCFHgEkTlpDRIMgUdHPGO3S59oVyAqqak0R11FttDZTxYoV76s9Wl9JR8/ZuHFjpHka7LXapCMCWaPtuGao+Pn5mYw61+LXSmu/aAAayRMBFAAAgGROL0S06GLmzJlN//6oaIBk06ZNsnr1avsFgE6bMGGCvf5JdHr06GEK0VpBFB1OVAvEai2V2NAuP1qc0RoBSH/R1SKPrrR4rGafVK9ePVbrBxD/RWQ1QKH1TzT4oZlvUdHuhStWrJC+ffuaQtF//PGHNGzY0D6c8ejRo2XOnDnyxhtvyNq1a2Xs2LGmRon+vR+akaddC3UEMK0TpV0PtW6TFqDdvHmzWUazZnS5li1bms9OreGkI5Xp55nS4LIOD//rr7/K9u3b7QFeDejqOnTEMiRPdOEBAABIxkVkNXhindzryb5r9xlH2oXH19fXdPGxUtA1gKJ1Uzp06OBxmzpkqF7g6C/D2oVIAyka3NALn9jQgpI6XLKuQ28aSNH1WBc3lu+//94MUaq/BgNIWFmyZDFBVquIrHYbtAqzRjcKj2aYaN2j8ePHm1ooWstEP7+srDXNMNOMEy0yrZkq+fLlk0WLFplMEosGUjUDzpVuX4O/rmbOnGmK0OqIYJrJpu1+++237cVmtWuQBm0++ugjU0hWa63okPCO3ZD081Wfo4Fj3Y6OxKNDwWvdKHdtQfLgZdOjAQAAAMmCnto5prtrmrmOTqEFEWMSaND0cy2AaKXHayq9duvRCwLrouDu3bsmS0XT3PUiydWpU6fkyJEjZruuGS/6C61mlGiwxrGOif6Kq786uxZ71BF6HnnkEfPL76xZs+xBlB07dpjCsppiH1V9FAB4WLROi2auaDaLDveO5IkACgAAABIdrbti/ZKtAZlatWqZX3q1S4DSAI3WK/DUrQgAgLhCAAUAAACJjtZB0SwXHe54586dphbBlClToi1GCQBAfCKAAgAAgETp7NmzcuzYMVNfQAMpAAAkJAIoAAAAAAAAHjCMMQAAAAAAgAcEUAAAAAAAADwggAIAAAAAAOABARQAAAAAAAAPCKAAAAAAAAB4QAAFAAAAAADAAwIoAAAAAAAAHhBAAQAAAAAA8IAACgAAAAAAgAcEUAAAAAAAACR6/w9pLgLbidN0iQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    import matplotlib.pyplot as plt\n",
+    "except ModuleNotFoundError:\n",
+    "    plt = None\n",
+    "\n",
+    "if plt is None:\n",
+    "    print('Matplotlib not installed in this environment; install from requirements.txt to see plots.')\n",
+    "else:\n",
+    "    fig, axes = plt.subplots(1, 2, figsize=(12, 4))\n",
+    "\n",
+    "    # Plot 1: 2x2 contingency heatmap\n",
+    "    table = [[a, b], [c, d]]\n",
+    "    ax = axes[0]\n",
+    "    im = ax.imshow(table, cmap='Blues')\n",
+    "    ax.set_xticks([0, 1], ['B correct', 'B wrong'])\n",
+    "    ax.set_yticks([0, 1], ['A correct', 'A wrong'])\n",
+    "    ax.set_title('2x2 contingency table')\n",
+    "    labels = [['a (both correct)', 'b (A>B)'], ['c (B>A)', 'd (both wrong)']]\n",
+    "    for i in range(2):\n",
+    "        for j in range(2):\n",
+    "            ax.text(j, i, f\"{labels[i][j]}\\n{table[i][j]}\",\n",
+    "                    ha='center', va='center', color='black')\n",
+    "\n",
+    "    # Plot 2: discordant counts\n",
+    "    ax = axes[1]\n",
+    "    bars = ax.bar(['b\\n(A correct,\\nB wrong)', 'c\\n(A wrong,\\nB correct)'],\n",
+    "                  [b, c], color=['tab:green', 'tab:red'], alpha=0.8)\n",
+    "    ax.set_title('Discordant pairs')\n",
+    "    ax.set_ylabel('Count')\n",
+    "    ax.axhline((b + c) / 2, color='gray', linestyle='--', linewidth=1,\n",
+    "               label='expected under H0')\n",
+    "    for rect, val in zip(bars, [b, c]):\n",
+    "        ax.text(rect.get_x() + rect.get_width() / 2, val, str(val),\n",
+    "                ha='center', va='bottom')\n",
+    "    ax.legend()\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6ad573e",
+   "metadata": {},
+   "source": [
+    "## 4) Compute McNemar's test statistic\n",
+    "\n",
+    "Under the null hypothesis the two models are equally accurate, so among the discordant pairs each one is equally likely to favor A or B. We expect `b` and `c` to be roughly equal.\n",
+    "\n",
+    "The classic McNemar statistic is\n",
+    "\n",
+    "$$\\chi^2 = \\frac{(b - c)^2}{b + c},$$\n",
+    "\n",
+    "which approximately follows a chi-squared distribution with 1 degree of freedom. A **continuity-corrected** version, better for small samples, is\n",
+    "\n",
+    "$$\\chi^2_{cc} = \\frac{(|b - c| - 1)^2}{b + c}.$$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e87efd4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "disc = b + c\n",
+    "\n",
+    "if disc == 0:\n",
+    "    chi2 = 0.0\n",
+    "    chi2_cc = 0.0\n",
+    "    print('No discordant pairs (b + c = 0): the models made identical decisions on every item.')\n",
+    "else:\n",
+    "    chi2 = (b - c) ** 2 / disc\n",
+    "    chi2_cc = (abs(b - c) - 1) ** 2 / disc if abs(b - c) >= 1 else 0.0\n",
+    "    print(f'b = {b}, c = {c}, discordant = {disc}')\n",
+    "    print(f'McNemar chi-squared (uncorrected): {chi2:.4f}')\n",
+    "    print(f'McNemar chi-squared (continuity-corrected): {chi2_cc:.4f}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6229d1c",
+   "metadata": {},
+   "source": [
+    "## 5) Compute the exact p-value from the null distribution\n",
+    "\n",
+    "For small samples we don't need the chi-squared approximation at all. Under the null hypothesis, each of the `b + c` discordant pairs is an independent fair coin flip favoring A or B. So `b` follows a **Binomial(b + c, 1/2)** distribution.\n",
+    "\n",
+    "The **exact two-sided p-value** is the probability of a split at least as imbalanced as the one observed:\n",
+    "\n",
+    "$$p = 2 \\cdot \\sum_{k=0}^{\\min(b,c)} \\binom{b+c}{k} \\left(\\tfrac{1}{2}\\right)^{b+c}, \\quad \\text{capped at } 1.$$\\n\\n_(We use this clean combinatorial formula directly for small samples, and switch to an equivalent log-space computation once there are many discordant pairs (> 200), so the cell stays fast for any `n` instead of forming huge integers like `2 ** (b + c)`.)_\\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bff468b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from math import comb, lgamma, log, exp\n",
+    "\n",
+    "def _exact_p_exact_int(b, c):\n",
+    "    \"\"\"Clean exact binomial-tail computation (great for small samples).\"\"\"\n",
+    "    n_disc = b + c\n",
+    "    k = min(b, c)\n",
+    "    tail = sum(comb(n_disc, i) for i in range(0, k + 1)) / (2 ** n_disc)\n",
+    "    return min(1.0, 2 * tail)\n",
+    "\n",
+    "def _exact_p_logspace(b, c):\n",
+    "    \"\"\"Numerically stable version for large samples (no huge integers).\"\"\"\n",
+    "    n_disc = b + c\n",
+    "    k = min(b, c)\n",
+    "    log_half_pow = n_disc * log(0.5)\n",
+    "    log_terms = [\n",
+    "        lgamma(n_disc + 1) - lgamma(i + 1) - lgamma(n_disc - i + 1) + log_half_pow\n",
+    "        for i in range(0, k + 1)\n",
+    "    ]\n",
+    "    m = max(log_terms)  # log-sum-exp for a stable tail sum\n",
+    "    log_tail = m + log(sum(exp(t - m) for t in log_terms))\n",
+    "    return min(1.0, 2 * exp(log_tail))\n",
+    "\n",
+    "def exact_two_sided_p_value(b, c):\n",
+    "    \"\"\"Exact two-sided McNemar p-value (binomial sign test on discordant pairs).\n",
+    "\n",
+    "    Uses the clean combinatorial formula for small samples, and switches to a\n",
+    "    log-space computation once there are many discordant pairs, where\n",
+    "    comb(...) and 2 ** (b + c) would form huge integers and become slow.\n",
+    "    \"\"\"\n",
+    "    n_disc = b + c\n",
+    "    if n_disc == 0:\n",
+    "        return 1.0\n",
+    "    if n_disc <= 200:\n",
+    "        return _exact_p_exact_int(b, c)\n",
+    "    return _exact_p_logspace(b, c)\n",
+    "\n",
+    "p_value_two_sided = exact_two_sided_p_value(b, c)\n",
+    "print(f'Exact two-sided p-value: {p_value_two_sided:.6f}')\n",
+    "print('Interpretation: smaller p-values provide stronger evidence that the models differ.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "891e7516",
+   "metadata": {},
+   "source": [
+    "## 6) Optional cross-check with SciPy / statsmodels (if installed)\n",
+    "\n",
+    "The exact McNemar test is mathematically identical to a two-sided binomial test on `b` out of `b + c` discordant pairs, which SciPy's `binomtest` computes directly. If `statsmodels` is available we also call its purpose-built `mcnemar` routine.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db185d07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from scipy.stats import binomtest\n",
+    "\n",
+    "    if (b + c) > 0:\n",
+    "        scipy_result = binomtest(b, b + c, 0.5, alternative='two-sided')\n",
+    "        print('SciPy binomtest (exact) p-value :', scipy_result.pvalue)\n",
+    "    else:\n",
+    "        print('SciPy check skipped: no discordant pairs.')\n",
+    "except ModuleNotFoundError:\n",
+    "    print('SciPy not installed in this environment; optional check skipped.')\n",
+    "\n",
+    "try:\n",
+    "    from statsmodels.stats.contingency_tables import mcnemar\n",
+    "\n",
+    "    result = mcnemar([[a, b], [c, d]], exact=True)\n",
+    "    print('statsmodels McNemar statistic:', result.statistic)\n",
+    "    print('statsmodels McNemar p-value  :', result.pvalue)\n",
+    "except ModuleNotFoundError:\n",
+    "    print('statsmodels not installed in this environment; optional check skipped.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02b2d8d2",
+   "metadata": {},
+   "source": [
+    "### Notes\n",
+    "- Change `acc_advantage_a` and rerun to see how the evidence changes. A larger advantage pushes `b` and `c` further apart.\n",
+    "- Increase `n` to see how larger test sets can detect smaller accuracy differences.\n",
+    "- Raise `correlation` to model items with shared difficulty: the models agree more often, shrinking `b + c`. McNemar's test correctly ignores those concordant items and stays powerful because it conditions only on the disagreements.\n",
+    "- Because McNemar's test looks only at discordant pairs, two models with very different overall accuracies can still produce a non-significant result if they disagree on only a handful of items.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (notebooks venv)",
+   "language": "python",
+   "name": "notebooks-venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jupyter>=1.0.0
 ipykernel>=6.0.0
 matplotlib>=3.7.0
 scipy>=1.10.0
+statsmodels>=0.14.0


### PR DESCRIPTION
## Summary

Adds `McNemarTestDemo.ipynb`, a step-by-step educational demo of **McNemar's test** — the standard, purpose-built test for paired binary outcomes on the same test items. It mirrors the style and structure of the existing `WilcoxonSignedRankDemo.ipynb`.

## What the notebook covers
1. **Settings** — test-set size `n`, model B accuracy, A's accuracy advantage, and a `correlation` knob for shared item difficulty.
2. **Simulate paired binary (correct/incorrect) outcomes** on the same test items.
3. **Build the 2×2 contingency table** (`a`/`b`/`c`/`d`), emphasizing that only discordant cells `b` and `c` carry information.
4. **Visualize** — contingency heatmap + discordant-pair bars vs. the null expectation.
5. **Compute the statistic** — uncorrected and continuity-corrected McNemar χ².
6. **Exact two-sided p-value** from first principles (binomial sign test on discordant pairs), using a clean combinatorial formula for small samples and a numerically stable **log-space** computation when there are many discordant pairs (> 200), so it stays fast for any `n`.
7. **Cross-check** with SciPy `binomtest` and statsmodels `mcnemar` — all three agree exactly.
8. **Notes** on interpretation and how the knobs affect the result.

## Other changes
- Add `statsmodels>=0.14.0` to `requirements.txt` for the statsmodels cross-check.

## Validation
- Notebook executes cleanly end to end.
- At defaults the hand-computed p-value (0.016125) matches SciPy and statsmodels to full precision.